### PR TITLE
feat: add audit revisions for players and matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The project is intentionally small, but built like a production service: databas
 
 - Server-rendered UI for player rankings and match history
 - Elo rating calculation with match cancellation and rating rollback
+- JSONB audit revisions for player and match mutations
 - PostgreSQL persistence with Flyway migrations
 - Integration tests backed by Testcontainers
 - Gradle quality gate with JaCoCo coverage verification
@@ -31,6 +32,7 @@ The project is intentionally small, but built like a production service: databas
 ```text
 src/main/java/com/emt
 ├── configuration   # MVC exception handling and OpenAPI configuration
+├── audit           # entity mutation audit listener and actor resolution
 ├── controller      # UI endpoints
 ├── entity          # JPA entities
 ├── mapper          # entity/DTO mapping
@@ -76,6 +78,8 @@ DB_NAME=elt_database
 DB_USERNAME=elt_user
 DB_PASSWORD=elt_pass
 DB_SCHEMA=app_elo_match_tracker
+AUDIT_ACTOR_HEADER=X-Actor
+AUDIT_FALLBACK_ACTOR=system
 ```
 
 For production, run with:
@@ -116,7 +120,7 @@ Flyway migrations live in:
 src/main/resources/db/migration
 ```
 
-Current migrations create player and match tables, store Elo rating deltas for match cancellation, and add indexes for match history queries.
+Current migrations create player, match, and audit revision tables, store Elo rating deltas for match cancellation, and add indexes for match history and audit lookups.
 
 ## Container Image
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,14 @@ Cancelling a match is treated as a data correction. The service reverses the can
 
 This keeps current player ratings consistent with the visible match history.
 
+## Auditing
+
+Player and match inserts, updates, and deletes are audited through Hibernate event listeners instead of ad-hoc service calls. That keeps audit behavior close to persistence and makes it harder for future features to accidentally bypass it.
+
+Each revision stores the affected entity type, entity id, operation, actor, timestamp, and a JSONB snapshot of the entity state. Player references inside match snapshots are stored as ids, not nested entity graphs, so the audit payload remains small and stable.
+
+The actor is read from a configurable request header (`AUDIT_ACTOR_HEADER`, default `X-Actor`). Non-web flows fall back to `AUDIT_FALLBACK_ACTOR`.
+
 ## Persistence
 
 The application uses PostgreSQL with Flyway migrations. Rating values are stored as `NUMERIC(10, 2)` to keep deterministic decimal behavior and avoid floating point drift.
@@ -25,6 +33,8 @@ Indexes exist for the match fields used by history and recalculation queries:
 - `winner_id`
 - `loser_id`
 - `created_at`
+
+Audit revisions are indexed by entity, operation, and creation time to support timeline and troubleshooting queries.
 
 ## Profiles
 

--- a/src/main/java/com/emt/audit/AuditActorProvider.java
+++ b/src/main/java/com/emt/audit/AuditActorProvider.java
@@ -1,0 +1,30 @@
+package com.emt.audit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+@RequiredArgsConstructor
+public class AuditActorProvider {
+
+  private final AuditProperties auditProperties;
+
+  public String currentActor() {
+    if (RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes attributes) {
+      return actorFrom(attributes.getRequest());
+    }
+    return auditProperties.getFallbackActor();
+  }
+
+  private String actorFrom(HttpServletRequest request) {
+    String actor = request.getHeader(auditProperties.getActorHeader());
+    if (StringUtils.hasText(actor)) {
+      return actor;
+    }
+    return auditProperties.getFallbackActor();
+  }
+}

--- a/src/main/java/com/emt/audit/AuditOperation.java
+++ b/src/main/java/com/emt/audit/AuditOperation.java
@@ -1,0 +1,7 @@
+package com.emt.audit;
+
+public enum AuditOperation {
+  INSERT,
+  UPDATE,
+  DELETE
+}

--- a/src/main/java/com/emt/audit/AuditProperties.java
+++ b/src/main/java/com/emt/audit/AuditProperties.java
@@ -1,0 +1,22 @@
+package com.emt.audit;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Component
+@Validated
+@ConfigurationProperties(prefix = "audit")
+public class AuditProperties {
+
+  @NotBlank
+  private String actorHeader = "X-Actor";
+
+  @NotBlank
+  private String fallbackActor = "system";
+}

--- a/src/main/java/com/emt/audit/AuditRevisionWriter.java
+++ b/src/main/java/com/emt/audit/AuditRevisionWriter.java
@@ -1,0 +1,66 @@
+package com.emt.audit;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditRevisionWriter {
+
+  private static final Pattern SAFE_SCHEMA_NAME = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+  private static final String INSERT_SQL =
+      """
+      INSERT INTO %s
+          (entity_name, entity_id, operation, entity_state, actor, created_at)
+      VALUES (?, ?, ?, ?::jsonb, ?, ?)
+      """;
+
+  private final JdbcTemplate jdbcTemplate;
+  private final ObjectMapper objectMapper;
+  private final AuditActorProvider auditActorProvider;
+  private final String insertSql;
+
+  public AuditRevisionWriter(
+      JdbcTemplate jdbcTemplate,
+      ObjectMapper objectMapper,
+      AuditActorProvider auditActorProvider,
+      @Value("${dbSchema}") String dbSchema) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.objectMapper = objectMapper;
+    this.auditActorProvider = auditActorProvider;
+    this.insertSql = INSERT_SQL.formatted(qualifiedAuditTable(dbSchema));
+  }
+
+  public void write(
+      String entityName, Long entityId, AuditOperation operation, Map<String, Object> entityState) {
+    jdbcTemplate.update(
+        insertSql,
+        entityName,
+        entityId,
+        operation.name(),
+        toJson(entityState),
+        auditActorProvider.currentActor(),
+        Timestamp.from(Instant.now()));
+  }
+
+  private String qualifiedAuditTable(String dbSchema) {
+    if (!SAFE_SCHEMA_NAME.matcher(dbSchema).matches()) {
+      throw new IllegalArgumentException("Unsafe database schema name: " + dbSchema);
+    }
+    return dbSchema + ".audit_revision";
+  }
+
+  private String toJson(Map<String, Object> entityState) {
+    try {
+      return objectMapper.writeValueAsString(entityState);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException("Failed to serialize audit entity state", ex);
+    }
+  }
+}

--- a/src/main/java/com/emt/audit/HibernateAuditEventListener.java
+++ b/src/main/java/com/emt/audit/HibernateAuditEventListener.java
@@ -1,0 +1,153 @@
+package com.emt.audit;
+
+import com.emt.entity.Match;
+import com.emt.entity.Player;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostInsertEvent;
+import org.hibernate.event.spi.PostInsertEventListener;
+import org.hibernate.event.spi.PreDeleteEvent;
+import org.hibernate.event.spi.PreDeleteEventListener;
+import org.hibernate.event.spi.PreUpdateEvent;
+import org.hibernate.event.spi.PreUpdateEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HibernateAuditEventListener
+    implements PostInsertEventListener, PreUpdateEventListener, PreDeleteEventListener {
+
+  private static final String MATCH_ENTITY = "match";
+  private static final String MATCH_ID = "matchId";
+  private static final String PLAYER_ENTITY = "player";
+  private static final String PLAYER_ID = "playerId";
+
+  private final EntityManagerFactory entityManagerFactory;
+  private final AuditRevisionWriter auditRevisionWriter;
+
+  @PostConstruct
+  public void registerListeners() {
+    EventListenerRegistry registry =
+        entityManagerFactory
+            .unwrap(SessionFactoryImplementor.class)
+            .getServiceRegistry()
+            .getService(EventListenerRegistry.class);
+
+    registry.appendListeners(EventType.POST_INSERT, this);
+    registry.appendListeners(EventType.PRE_UPDATE, this);
+    registry.appendListeners(EventType.PRE_DELETE, this);
+  }
+
+  @Override
+  public void onPostInsert(PostInsertEvent event) {
+    writeRevision(
+        event.getEntity(),
+        event.getId(),
+        AuditOperation.INSERT,
+        event.getPersister().getPropertyNames(),
+        event.getState());
+  }
+
+  @Override
+  public boolean onPreUpdate(PreUpdateEvent event) {
+    Object[] stateBeforeUpdate =
+        event.getOldState() == null ? event.getState() : event.getOldState();
+    writeRevision(
+        event.getEntity(),
+        event.getId(),
+        AuditOperation.UPDATE,
+        event.getPersister().getPropertyNames(),
+        stateBeforeUpdate);
+    return false;
+  }
+
+  @Override
+  public boolean onPreDelete(PreDeleteEvent event) {
+    writeRevision(
+        event.getEntity(),
+        event.getId(),
+        AuditOperation.DELETE,
+        event.getPersister().getPropertyNames(),
+        event.getDeletedState());
+    return false;
+  }
+
+  @Override
+  public boolean requiresPostCommitHandling(EntityPersister persister) {
+    return false;
+  }
+
+  private void writeRevision(
+      Object entity,
+      Object entityId,
+      AuditOperation operation,
+      String[] propertyNames,
+      Object[] propertyValues) {
+    AuditedEntity auditedEntity = auditedEntity(entity);
+    if (auditedEntity == null) {
+      return;
+    }
+
+    auditRevisionWriter.write(
+        auditedEntity.entityName(),
+        asLong(entityId),
+        operation,
+        entityState(auditedEntity, entityId, propertyNames, propertyValues));
+  }
+
+  private Map<String, Object> entityState(
+      AuditedEntity auditedEntity, Object entityId, String[] propertyNames, Object[] propertyValues) {
+    Map<String, Object> entityState = new LinkedHashMap<>();
+    entityState.put(auditedEntity.idProperty(), asLong(entityId));
+
+    for (int i = 0; i < propertyNames.length; i++) {
+      entityState.put(propertyNames[i], normalizedValue(propertyValues[i]));
+    }
+
+    return entityState;
+  }
+
+  private Object normalizedValue(Object value) {
+    if (value == null
+        || value instanceof String
+        || value instanceof Number
+        || value instanceof Boolean
+        || value instanceof Instant) {
+      return value;
+    }
+    if (value instanceof Player player) {
+      return player.getPlayerId();
+    }
+    if (value instanceof Match match) {
+      return match.getMatchId();
+    }
+    return value.toString();
+  }
+
+  private Long asLong(Object entityId) {
+    if (entityId instanceof Number number) {
+      return number.longValue();
+    }
+    throw new IllegalArgumentException("Audited entity id must be numeric: " + entityId);
+  }
+
+  private AuditedEntity auditedEntity(Object entity) {
+    if (entity instanceof Player) {
+      return new AuditedEntity(PLAYER_ENTITY, PLAYER_ID);
+    }
+    if (entity instanceof Match) {
+      return new AuditedEntity(MATCH_ENTITY, MATCH_ID);
+    }
+    return null;
+  }
+
+  private record AuditedEntity(String entityName, String idProperty) {}
+}

--- a/src/main/java/com/emt/entity/AuditRevision.java
+++ b/src/main/java/com/emt/entity/AuditRevision.java
@@ -1,0 +1,45 @@
+package com.emt.entity;
+
+import com.emt.audit.AuditOperation;
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "audit_revision")
+public class AuditRevision {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long auditRevisionId;
+
+  @Column(nullable = false)
+  private String entityName;
+
+  @Column(nullable = false)
+  private Long entityId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private AuditOperation operation;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private Map<String, Object> entityState;
+
+  @Column(nullable = false)
+  private String actor;
+
+  @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE", nullable = false)
+  private Instant createdAt;
+}

--- a/src/main/java/com/emt/repository/AuditRevisionRepository.java
+++ b/src/main/java/com/emt/repository/AuditRevisionRepository.java
@@ -1,0 +1,15 @@
+package com.emt.repository;
+
+import com.emt.audit.AuditOperation;
+import com.emt.entity.AuditRevision;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuditRevisionRepository extends JpaRepository<AuditRevision, Long> {
+
+  List<AuditRevision> findByEntityNameAndEntityIdOrderByCreatedAtAsc(
+      String entityName, Long entityId);
+
+  List<AuditRevision> findByEntityNameAndOperationOrderByCreatedAtAsc(
+      String entityName, AuditOperation operation);
+}

--- a/src/main/java/com/emt/repository/PlayerRepository.java
+++ b/src/main/java/com/emt/repository/PlayerRepository.java
@@ -1,10 +1,13 @@
 package com.emt.repository;
 
 import com.emt.entity.Player;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PlayerRepository extends JpaRepository<Player, Long> {
   boolean existsByNickname(String nickname);
+
+  Optional<Player> findByNickname(String nickname);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,10 @@ dbPassword: ${DB_PASSWORD:elt_pass}
 dbApplicationName: ${spring.application.name}
 dbSchema: ${DB_SCHEMA:app_elo_match_tracker}
 
+audit:
+  actor-header: ${AUDIT_ACTOR_HEADER:X-Actor}
+  fallback-actor: ${AUDIT_FALLBACK_ACTOR:system}
+
 spring:
   application:
     name: elo_match_tracker

--- a/src/main/resources/db/migration/V05__create_audit_revision_table.sql
+++ b/src/main/resources/db/migration/V05__create_audit_revision_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE audit_revision
+(
+    audit_revision_id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    entity_name       TEXT                     NOT NULL,
+    entity_id         BIGINT                   NOT NULL,
+    operation         TEXT                     NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+    entity_state      JSONB                    NOT NULL,
+    actor             TEXT                     NOT NULL,
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_revision_entity ON audit_revision (entity_name, entity_id);
+CREATE INDEX IF NOT EXISTS idx_audit_revision_operation ON audit_revision (operation);
+CREATE INDEX IF NOT EXISTS idx_audit_revision_created_at ON audit_revision (created_at);

--- a/src/test/integration/java/com/emt/audit/AuditRevisionIT.java
+++ b/src/test/integration/java/com/emt/audit/AuditRevisionIT.java
@@ -1,0 +1,160 @@
+package com.emt.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.emt.ITBase;
+import com.emt.entity.AuditRevision;
+import com.emt.entity.Match;
+import com.emt.entity.Player;
+import com.emt.repository.AuditRevisionRepository;
+import com.emt.repository.MatchRepository;
+import com.emt.repository.PlayerRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class AuditRevisionIT extends ITBase {
+
+  private static final String ACTOR_HEADER = "X-Actor";
+  private static final String MATCH_ENTITY = "match";
+  private static final String PLAYER_ENTITY = "player";
+  private static final String SEED_ACTOR = "seed-user";
+
+  private final AuditRevisionRepository auditRevisionRepository;
+  private final MatchRepository matchRepository;
+  private final MockMvc mockMvc;
+  private final PlayerRepository playerRepository;
+
+  @BeforeEach
+  void cleanDatabase() {
+    deleteTestData();
+  }
+
+  @AfterEach
+  void cleanDatabaseAfterTest() {
+    deleteTestData();
+  }
+
+  @Test
+  void registerPlayer_withActorHeader_shouldStorePlayerInsertRevision() throws Exception {
+    mockMvc
+        .perform(
+            post("/players/register")
+                .header(ACTOR_HEADER, "portfolio-reviewer")
+                .param("nickname", "AuditedPlayer"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/players"));
+
+    Player player = playerRepository.findByNickname("AuditedPlayer").orElseThrow();
+    List<AuditRevision> revisions =
+        auditRevisionRepository.findByEntityNameAndEntityIdOrderByCreatedAtAsc(
+            PLAYER_ENTITY, player.getPlayerId());
+
+    assertThat(revisions).hasSize(1);
+
+    AuditRevision revision = revisions.get(0);
+    assertThat(revision.getOperation()).isEqualTo(AuditOperation.INSERT);
+    assertThat(revision.getActor()).isEqualTo("portfolio-reviewer");
+    assertThat(revision.getCreatedAt()).isNotNull();
+    assertThat(stateId(revision, "playerId")).isEqualTo(player.getPlayerId());
+    assertThat(revision.getEntityState()).containsEntry("nickname", "AuditedPlayer");
+  }
+
+  @Test
+  void reportMatch_withActorHeader_shouldStoreMatchAndRatingRevisions() throws Exception {
+    Player winner = createPlayer("AuditWinner", SEED_ACTOR);
+    Player loser = createPlayer("AuditLoser", SEED_ACTOR);
+    auditRevisionRepository.deleteAll();
+
+    mockMvc
+        .perform(
+            post("/matches/report")
+                .header(ACTOR_HEADER, "match-reporter")
+                .param("winnerId", String.valueOf(winner.getPlayerId()))
+                .param("loserId", String.valueOf(loser.getPlayerId())))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/players"));
+
+    Match match = matchRepository.findAll().get(0);
+    List<AuditRevision> matchRevisions =
+        auditRevisionRepository.findByEntityNameAndEntityIdOrderByCreatedAtAsc(
+            MATCH_ENTITY, match.getMatchId());
+    List<AuditRevision> playerUpdates =
+        auditRevisionRepository.findByEntityNameAndOperationOrderByCreatedAtAsc(
+            PLAYER_ENTITY, AuditOperation.UPDATE);
+
+    assertThat(matchRevisions).hasSize(1);
+    assertThat(matchRevisions.get(0).getActor()).isEqualTo("match-reporter");
+    assertThat(stateId(matchRevisions.get(0), "winner")).isEqualTo(winner.getPlayerId());
+    assertThat(stateId(matchRevisions.get(0), "loser")).isEqualTo(loser.getPlayerId());
+
+    assertThat(playerUpdates)
+        .hasSize(2)
+        .allSatisfy(revision -> assertThat(revision.getActor()).isEqualTo("match-reporter"));
+  }
+
+  @Test
+  void cancelMatch_withActorHeader_shouldStoreDeletedMatchState() throws Exception {
+    Player winner = createPlayer("CancelWinner", SEED_ACTOR);
+    Player loser = createPlayer("CancelLoser", SEED_ACTOR);
+    createMatch(winner, loser, SEED_ACTOR);
+    Match match = matchRepository.findAll().get(0);
+    auditRevisionRepository.deleteAll();
+
+    mockMvc
+        .perform(
+            post("/matches/cancel")
+                .header(ACTOR_HEADER, "admin-user")
+                .param("matchId", String.valueOf(match.getMatchId())))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/matches"));
+
+    List<AuditRevision> matchRevisions =
+        auditRevisionRepository.findByEntityNameAndEntityIdOrderByCreatedAtAsc(
+            MATCH_ENTITY, match.getMatchId());
+
+    assertThat(matchRevisions).hasSize(1);
+    assertThat(matchRevisions.get(0).getOperation()).isEqualTo(AuditOperation.DELETE);
+    assertThat(matchRevisions.get(0).getActor()).isEqualTo("admin-user");
+    assertThat(stateId(matchRevisions.get(0), "matchId")).isEqualTo(match.getMatchId());
+    assertThat(stateId(matchRevisions.get(0), "winner")).isEqualTo(winner.getPlayerId());
+    assertThat(stateId(matchRevisions.get(0), "loser")).isEqualTo(loser.getPlayerId());
+  }
+
+  private Player createPlayer(String nickname, String actor) throws Exception {
+    mockMvc
+        .perform(post("/players/register").header(ACTOR_HEADER, actor).param("nickname", nickname))
+        .andExpect(status().is3xxRedirection());
+    return playerRepository.findByNickname(nickname).orElseThrow();
+  }
+
+  private void createMatch(Player winner, Player loser, String actor) throws Exception {
+    mockMvc
+        .perform(
+            post("/matches/report")
+                .header(ACTOR_HEADER, actor)
+                .param("winnerId", String.valueOf(winner.getPlayerId()))
+                .param("loserId", String.valueOf(loser.getPlayerId())))
+        .andExpect(status().is3xxRedirection());
+  }
+
+  private void deleteTestData() {
+    matchRepository.deleteAllInBatch();
+    playerRepository.deleteAllInBatch();
+    auditRevisionRepository.deleteAllInBatch();
+  }
+
+  private Long stateId(AuditRevision revision, String key) {
+    return ((Number) revision.getEntityState().get(key)).longValue();
+  }
+}

--- a/src/test/integration/java/com/emt/audit/AuditRevisionIT.java
+++ b/src/test/integration/java/com/emt/audit/AuditRevisionIT.java
@@ -12,6 +12,7 @@ import com.emt.entity.Player;
 import com.emt.repository.AuditRevisionRepository;
 import com.emt.repository.MatchRepository;
 import com.emt.repository.PlayerRepository;
+import java.math.BigDecimal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.AfterEach;
@@ -26,11 +27,25 @@ import org.springframework.transaction.annotation.Transactional;
 class AuditRevisionIT extends ITBase {
 
   private static final String ACTOR_HEADER = "X-Actor";
+  private static final String ELO_RATING_FIELD = "eloRating";
+  private static final String LOSER_FIELD = "loser";
+  private static final String LOSER_ID_PARAM = "loserId";
+  private static final String MATCHES_PATH = "/matches";
   private static final String MATCH_ENTITY = "match";
+  private static final String MATCH_ID_FIELD = "matchId";
+  private static final String MATCH_ID_PARAM = "matchId";
+  private static final String MATCH_REPORT_PATH = "/matches/report";
+  private static final String NICKNAME_PARAM = "nickname";
   private static final String PLAYER_ENTITY = "player";
+  private static final String PLAYER_ID_FIELD = "playerId";
+  private static final String PLAYER_REGISTER_PATH = "/players/register";
+  private static final String PLAYERS_PATH = "/players";
   private static final String SEED_ACTOR = "seed-user";
+  private static final String WINNER_FIELD = "winner";
+  private static final String WINNER_ID_PARAM = "winnerId";
 
   private final AuditRevisionRepository auditRevisionRepository;
+  private final AuditProperties auditProperties;
   private final MatchRepository matchRepository;
   private final MockMvc mockMvc;
   private final PlayerRepository playerRepository;
@@ -49,11 +64,11 @@ class AuditRevisionIT extends ITBase {
   void registerPlayer_withActorHeader_shouldStorePlayerInsertRevision() throws Exception {
     mockMvc
         .perform(
-            post("/players/register")
+            post(PLAYER_REGISTER_PATH)
                 .header(ACTOR_HEADER, "portfolio-reviewer")
-                .param("nickname", "AuditedPlayer"))
+                .param(NICKNAME_PARAM, "AuditedPlayer"))
         .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl("/players"));
+        .andExpect(redirectedUrl(PLAYERS_PATH));
 
     Player player = playerRepository.findByNickname("AuditedPlayer").orElseThrow();
     List<AuditRevision> revisions =
@@ -66,8 +81,37 @@ class AuditRevisionIT extends ITBase {
     assertThat(revision.getOperation()).isEqualTo(AuditOperation.INSERT);
     assertThat(revision.getActor()).isEqualTo("portfolio-reviewer");
     assertThat(revision.getCreatedAt()).isNotNull();
-    assertThat(stateId(revision, "playerId")).isEqualTo(player.getPlayerId());
-    assertThat(revision.getEntityState()).containsEntry("nickname", "AuditedPlayer");
+    assertThat(stateId(revision, PLAYER_ID_FIELD)).isEqualTo(player.getPlayerId());
+    assertThat(revision.getEntityState()).containsEntry(NICKNAME_PARAM, "AuditedPlayer");
+  }
+
+  @Test
+  void registerPlayer_withoutActorHeader_shouldUseFallbackActor() throws Exception {
+    mockMvc
+        .perform(post(PLAYER_REGISTER_PATH).param(NICKNAME_PARAM, "AuditedPlayerNoHeader"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(PLAYERS_PATH));
+
+    Player player = playerRepository.findByNickname("AuditedPlayerNoHeader").orElseThrow();
+
+    assertThat(latestPlayerRevision(player).getActor())
+        .isEqualTo(auditProperties.getFallbackActor());
+  }
+
+  @Test
+  void registerPlayer_withBlankActorHeader_shouldUseFallbackActor() throws Exception {
+    mockMvc
+        .perform(
+            post(PLAYER_REGISTER_PATH)
+                .header(ACTOR_HEADER, "   ")
+                .param(NICKNAME_PARAM, "AuditedPlayerBlankHeader"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(PLAYERS_PATH));
+
+    Player player = playerRepository.findByNickname("AuditedPlayerBlankHeader").orElseThrow();
+
+    assertThat(latestPlayerRevision(player).getActor())
+        .isEqualTo(auditProperties.getFallbackActor());
   }
 
   @Test
@@ -78,12 +122,12 @@ class AuditRevisionIT extends ITBase {
 
     mockMvc
         .perform(
-            post("/matches/report")
+            post(MATCH_REPORT_PATH)
                 .header(ACTOR_HEADER, "match-reporter")
-                .param("winnerId", String.valueOf(winner.getPlayerId()))
-                .param("loserId", String.valueOf(loser.getPlayerId())))
+                .param(WINNER_ID_PARAM, String.valueOf(winner.getPlayerId()))
+                .param(LOSER_ID_PARAM, String.valueOf(loser.getPlayerId())))
         .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl("/players"));
+        .andExpect(redirectedUrl(PLAYERS_PATH));
 
     Match match = matchRepository.findAll().get(0);
     List<AuditRevision> matchRevisions =
@@ -94,13 +138,31 @@ class AuditRevisionIT extends ITBase {
             PLAYER_ENTITY, AuditOperation.UPDATE);
 
     assertThat(matchRevisions).hasSize(1);
-    assertThat(matchRevisions.get(0).getActor()).isEqualTo("match-reporter");
-    assertThat(stateId(matchRevisions.get(0), "winner")).isEqualTo(winner.getPlayerId());
-    assertThat(stateId(matchRevisions.get(0), "loser")).isEqualTo(loser.getPlayerId());
+    AuditRevision matchRevision = matchRevisions.get(0);
+    assertThat(matchRevision.getOperation()).isEqualTo(AuditOperation.INSERT);
+    assertThat(matchRevision.getActor()).isEqualTo("match-reporter");
+    assertThat(matchRevision.getCreatedAt()).isNotNull();
+    assertThat(stateId(matchRevision, MATCH_ID_FIELD)).isEqualTo(match.getMatchId());
+    assertThat(stateId(matchRevision, WINNER_FIELD)).isEqualTo(winner.getPlayerId());
+    assertThat(stateId(matchRevision, LOSER_FIELD)).isEqualTo(loser.getPlayerId());
+    assertThat(matchRevision.getEntityState()).containsKeys("createdAt", "winnerRatingChange");
 
     assertThat(playerUpdates)
         .hasSize(2)
-        .allSatisfy(revision -> assertThat(revision.getActor()).isEqualTo("match-reporter"));
+        .allSatisfy(
+            revision -> {
+              assertThat(revision.getOperation()).isEqualTo(AuditOperation.UPDATE);
+              assertThat(revision.getActor()).isEqualTo("match-reporter");
+              assertThat(revision.getCreatedAt()).isNotNull();
+              assertThat(revision.getEntityState()).containsKeys(PLAYER_ID_FIELD, ELO_RATING_FIELD);
+            });
+
+    AuditRevision winnerRevision = playerUpdateFor(playerUpdates, winner);
+    AuditRevision loserRevision = playerUpdateFor(playerUpdates, loser);
+    assertThat(winnerRevision.getEntityState()).containsEntry(NICKNAME_PARAM, winner.getNickname());
+    assertThat(loserRevision.getEntityState()).containsEntry(NICKNAME_PARAM, loser.getNickname());
+    assertThat(stateDecimal(winnerRevision, ELO_RATING_FIELD)).isEqualByComparingTo("1200");
+    assertThat(stateDecimal(loserRevision, ELO_RATING_FIELD)).isEqualByComparingTo("1200");
   }
 
   @Test
@@ -115,9 +177,9 @@ class AuditRevisionIT extends ITBase {
         .perform(
             post("/matches/cancel")
                 .header(ACTOR_HEADER, "admin-user")
-                .param("matchId", String.valueOf(match.getMatchId())))
+                .param(MATCH_ID_PARAM, String.valueOf(match.getMatchId())))
         .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl("/matches"));
+        .andExpect(redirectedUrl(MATCHES_PATH));
 
     List<AuditRevision> matchRevisions =
         auditRevisionRepository.findByEntityNameAndEntityIdOrderByCreatedAtAsc(
@@ -126,14 +188,15 @@ class AuditRevisionIT extends ITBase {
     assertThat(matchRevisions).hasSize(1);
     assertThat(matchRevisions.get(0).getOperation()).isEqualTo(AuditOperation.DELETE);
     assertThat(matchRevisions.get(0).getActor()).isEqualTo("admin-user");
-    assertThat(stateId(matchRevisions.get(0), "matchId")).isEqualTo(match.getMatchId());
-    assertThat(stateId(matchRevisions.get(0), "winner")).isEqualTo(winner.getPlayerId());
-    assertThat(stateId(matchRevisions.get(0), "loser")).isEqualTo(loser.getPlayerId());
+    assertThat(stateId(matchRevisions.get(0), MATCH_ID_FIELD)).isEqualTo(match.getMatchId());
+    assertThat(stateId(matchRevisions.get(0), WINNER_FIELD)).isEqualTo(winner.getPlayerId());
+    assertThat(stateId(matchRevisions.get(0), LOSER_FIELD)).isEqualTo(loser.getPlayerId());
   }
 
   private Player createPlayer(String nickname, String actor) throws Exception {
     mockMvc
-        .perform(post("/players/register").header(ACTOR_HEADER, actor).param("nickname", nickname))
+        .perform(
+            post(PLAYER_REGISTER_PATH).header(ACTOR_HEADER, actor).param(NICKNAME_PARAM, nickname))
         .andExpect(status().is3xxRedirection());
     return playerRepository.findByNickname(nickname).orElseThrow();
   }
@@ -141,10 +204,10 @@ class AuditRevisionIT extends ITBase {
   private void createMatch(Player winner, Player loser, String actor) throws Exception {
     mockMvc
         .perform(
-            post("/matches/report")
+            post(MATCH_REPORT_PATH)
                 .header(ACTOR_HEADER, actor)
-                .param("winnerId", String.valueOf(winner.getPlayerId()))
-                .param("loserId", String.valueOf(loser.getPlayerId())))
+                .param(WINNER_ID_PARAM, String.valueOf(winner.getPlayerId()))
+                .param(LOSER_ID_PARAM, String.valueOf(loser.getPlayerId())))
         .andExpect(status().is3xxRedirection());
   }
 
@@ -156,5 +219,24 @@ class AuditRevisionIT extends ITBase {
 
   private Long stateId(AuditRevision revision, String key) {
     return ((Number) revision.getEntityState().get(key)).longValue();
+  }
+
+  private BigDecimal stateDecimal(AuditRevision revision, String key) {
+    return new BigDecimal(revision.getEntityState().get(key).toString());
+  }
+
+  private AuditRevision latestPlayerRevision(Player player) {
+    List<AuditRevision> revisions =
+        auditRevisionRepository.findByEntityNameAndEntityIdOrderByCreatedAtAsc(
+            PLAYER_ENTITY, player.getPlayerId());
+    assertThat(revisions).isNotEmpty();
+    return revisions.get(revisions.size() - 1);
+  }
+
+  private AuditRevision playerUpdateFor(List<AuditRevision> revisions, Player player) {
+    return revisions.stream()
+        .filter(revision -> stateId(revision, PLAYER_ID_FIELD).equals(player.getPlayerId()))
+        .findFirst()
+        .orElseThrow();
   }
 }


### PR DESCRIPTION
## Summary

Implemented audit revisions for Player and Match entity mutations.

## Changes

- Added Hibernate-based audit listener for insert/update/delete events
- Added `audit_revision` table with JSONB state snapshots
- Added actor resolution from configurable request header
- Added integration coverage for player and match audit flows
- Updated README and architecture documentation

## Verification

- `./gradlew clean check`
- `PATH="/usr/local/bin:/opt/homebrew/bin:$PATH" ./gradlew --no-daemon end2end`
- Manual boot check with PostgreSQL and audit row verification

## Summary by Sourcery

Introduce centralized auditing for player and match entity mutations with JSONB-backed revision storage and configurable actor resolution.

New Features:
- Persist audit revisions for player and match inserts, updates, and deletes using a dedicated audit_revision table with JSONB state snapshots.
- Resolve the audit actor from a configurable HTTP header with a fallback value for non-web or missing-header flows.
- Expose repository accessors for querying audit revisions by entity and operation, and for looking up players by nickname.

Enhancements:
- Register Hibernate event listeners to automatically capture and normalize entity state for audited operations, including ID-only references for related entities.
- Document the auditing model, configuration properties, and schema changes in the project README and architecture guide.

Documentation:
- Update architecture and README documentation to describe the new auditing behavior, configuration options, and audit-related database schema additions.

Tests:
- Add integration tests that verify audit revisions are written for player registration, match reporting, and match cancellation with the correct actor and entity payload.