### PR TITLE
feat: add filtered match history and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The project is intentionally small, but built like a production service: databas
 ## Highlights
 
 - Server-rendered UI for player rankings and match history
-- Elo rating calculation with match cancellation and rating rollback
+- Elo rating calculation with match cancellation, rating rollback, and match history filters
 - JSONB audit revisions for player and match mutations
 - PostgreSQL persistence with Flyway migrations
 - Integration tests backed by Testcontainers
@@ -134,6 +134,7 @@ The image name is assembled from `repository` and `serviceName` in `gradle.prope
 
 ## Documentation
 
+- [API and Domain Behavior](docs/API.md)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Contributing](CONTRIBUTING.md)
 - [Security](SECURITY.md)
@@ -144,4 +145,6 @@ The image name is assembled from `repository` and `serviceName` in `gradle.prope
 - Add a separate REST API layer for external clients
 - Add player search and pagination
 - Add match notes and optional game modes
+- Add request filtering by restricted header-value combinations
+- Add tournament management with configurable brackets and game rules
 - Add authentication for administrative actions

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,268 @@
+# API and Domain Behavior
+
+Elo Match Tracker currently exposes a server-rendered MVC interface. The endpoints below return HTML views or redirects rather than JSON response bodies. This keeps the UI simple today while leaving the service layer ready for a dedicated REST API in the future.
+
+## Base URLs
+
+- Application UI: `http://localhost:8080`
+- Management server: `http://localhost:9090`
+- Swagger UI in local profile: `http://localhost:8080/swagger-ui.html`
+
+## OpenAPI and Swagger
+
+OpenAPI documentation is enabled for local development:
+
+- OpenAPI JSON: `GET /v3/api-docs`
+- Swagger UI: `GET /swagger-ui.html`
+
+Because the current application is server-rendered MVC, the generated OpenAPI document is mainly a local discovery placeholder with project metadata. The MVC routes are documented manually in this file. A future REST layer should expose JSON endpoints through `@RestController` and become the primary OpenAPI contract.
+
+The `prod` profile disables both OpenAPI docs and Swagger UI. This keeps local discovery convenient while avoiding public API documentation exposure in production.
+
+## Request Headers
+
+| Header | Required | Description |
+| --- | --- | --- |
+| `X-Actor` | No | Optional actor identifier used by auditing. The header name is configurable through `AUDIT_ACTOR_HEADER`. Missing or blank values fall back to `AUDIT_FALLBACK_ACTOR`, which defaults to `system`. |
+
+## Player Endpoints
+
+### `GET /players`
+
+Renders the leaderboard page.
+
+The page includes:
+
+- all registered players sorted by Elo rating descending
+- the player registration form
+- the match reporting form
+
+Successful response:
+
+- Status: `200 OK`
+- View: `elo-ranking`
+
+### `POST /players/register`
+
+Registers a new player.
+
+Form parameters:
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `nickname` | Yes | Unique player nickname. Must satisfy the validation constraints from `CreatePlayerRequest`. |
+
+Successful response:
+
+- Status: `3xx redirect`
+- Redirect: `/players`
+- Flash message: `Player added successfully!`
+
+Error behavior:
+
+- duplicate nickname redirects back with an error flash message
+- validation errors redirect back with field-level flash errors
+
+Example:
+
+```bash
+curl -i -X POST \
+  -H 'X-Actor: portfolio-demo' \
+  -d 'nickname=Alice' \
+  http://localhost:8080/players/register
+```
+
+## Match Endpoints
+
+### `GET /matches`
+
+Renders the match history page.
+
+Query parameters:
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `playerId` | No | Filters history to matches where the selected player was either winner or loser. |
+| `opponentId` | No | When used with `playerId`, filters to head-to-head matches between both players. When used alone, behaves like a single-player filter. |
+
+Filtering semantics:
+
+- no filters: show all matches
+- only `playerId`: show all matches involving that player
+- only `opponentId`: show all matches involving that player
+- both ids and different values: show head-to-head matches in either winner/loser direction
+- both ids and the same value: show that player's full match history
+
+Successful response:
+
+- Status: `200 OK`
+- View: `match-history`
+
+Examples:
+
+```bash
+curl -i http://localhost:8080/matches
+curl -i 'http://localhost:8080/matches?playerId=1'
+curl -i 'http://localhost:8080/matches?playerId=1&opponentId=2'
+```
+
+### `POST /matches/report`
+
+Reports a match result and updates both players' Elo ratings in one transaction.
+
+Form parameters:
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `winnerId` | Yes | Player id of the match winner. |
+| `loserId` | Yes | Player id of the match loser. |
+
+Successful response:
+
+- Status: `3xx redirect`
+- Redirect: `/players`
+- Flash message: `Match reported successfully!`
+
+Error behavior:
+
+- identical winner and loser ids are rejected
+- unknown player ids redirect back with an error flash message
+- validation errors redirect back with field-level flash errors
+
+Example:
+
+```bash
+curl -i -X POST \
+  -H 'X-Actor: match-reporter' \
+  -d 'winnerId=1&loserId=2' \
+  http://localhost:8080/matches/report
+```
+
+### `POST /matches/cancel`
+
+Cancels a recorded match and repairs affected Elo ratings.
+
+Form parameters:
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `matchId` | Yes | Match id to cancel. |
+
+Successful response:
+
+- Status: `3xx redirect`
+- Redirect: `/matches`
+- Flash message: `Match cancelled successfully!`
+
+Error behavior:
+
+- unknown match ids redirect back with an error flash message
+
+Example:
+
+```bash
+curl -i -X POST \
+  -H 'X-Actor: admin-user' \
+  -d 'matchId=42' \
+  http://localhost:8080/matches/cancel
+```
+
+## Management Endpoints
+
+### `GET /actuator/health`
+
+Returns application health from the management server.
+
+Successful response:
+
+- Status: `200 OK`
+- Body includes status such as `UP`
+
+Example:
+
+```bash
+curl -i http://localhost:9090/actuator/health
+```
+
+## Elo Rating Model
+
+Every player starts with an Elo rating of `1200`.
+
+When a match is reported, the service calculates the winner's expected score using the standard Elo probability formula:
+
+```text
+expectedWinner = 1 / (1 + 10 ^ ((loserRating - winnerRating) / 400))
+```
+
+The project uses a constant K-factor of `30`:
+
+```text
+winnerRatingChange = 30 * (1 - expectedWinner)
+loserRatingChange = -winnerRatingChange
+```
+
+Then both ratings are updated in the same transaction:
+
+```text
+winner.rating = winner.rating + winnerRatingChange
+loser.rating = loser.rating - winnerRatingChange
+```
+
+Rating values are persisted as `NUMERIC(10, 2)` in PostgreSQL to avoid floating-point drift.
+
+## Match Cancellation and Rating Repair
+
+A match cancellation is treated as a data correction rather than a simple delete.
+
+The cancellation flow does three things:
+
+1. Loads the match being cancelled.
+2. Reverts the stored rating delta for the winner and loser.
+3. Recalculates later matches involving either affected player, then deletes the cancelled match.
+
+This matters because Elo is order-sensitive. Removing an old result can change the rating context for later matches, so the service repairs the downstream rating history instead of only deleting one row.
+
+## Match History Filtering
+
+Match history queries use fetch joins for `winner` and `loser` to keep the rendered page from triggering N+1 lazy loading.
+
+The head-to-head filter is direction-agnostic. A request for `playerId=1&opponentId=2` returns both:
+
+- matches where player `1` beat player `2`
+- matches where player `2` beat player `1`
+
+## Auditing Behavior
+
+Mutations for `Player` and `Match` are audited through Hibernate event listeners.
+
+Each audit revision stores:
+
+- entity name
+- entity id
+- operation (`INSERT`, `UPDATE`, `DELETE`)
+- JSONB snapshot of entity state
+- actor from the configured request header
+- timestamp with time zone
+
+Audit writes participate in the same transactional flow as the entity mutation. Match snapshots store player references as ids instead of nested entity graphs, keeping audit payloads compact and stable.
+
+## Error Handling
+
+The current MVC controllers use redirect-based error handling:
+
+- validation errors are stored as flash attributes
+- domain exceptions are shown as flash error messages
+- `/matches/report` errors redirect to `/players`
+- other `/matches` errors redirect to `/matches`
+- player errors redirect to `/players`
+
+Because this is currently an MVC-first application, clients should not expect JSON error payloads from these endpoints.
+
+## Future REST API Notes
+
+The service and repository layers are intentionally separated from MVC controllers. A future REST API can reuse the same business logic while adding:
+
+- JSON request and response models
+- explicit HTTP status codes for domain errors
+- pagination for player and match history queries
+- authentication and authorization controls

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,8 @@ Elo Match Tracker is a layered Spring Boot application. The current interface is
 2. `PlayerService` validates nickname uniqueness and persists the player.
 3. A match is reported through `MatchController`.
 4. `MatchService` loads both players, calculates the Elo delta, updates both ratings, and saves the match in one transaction.
-5. Match history is read with a fetch join to avoid lazy-loading each player row individually.
+5. Match history is read with fetch joins to avoid lazy-loading each player row individually.
+6. Match history can be filtered by one player or by a head-to-head pair through query parameters.
 
 ## Match Cancellation
 

--- a/src/main/java/com/emt/configuration/OpenApiConfiguration.java
+++ b/src/main/java/com/emt/configuration/OpenApiConfiguration.java
@@ -1,9 +1,17 @@
 package com.emt.configuration;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@OpenAPIDefinition(servers = @Server(url = "http://localhost:8080", description = "Local server"))
+@OpenAPIDefinition(
+    info =
+        @Info(
+            title = "Elo Match Tracker",
+            version = "0.0.1",
+            description =
+                "Server-rendered Elo ranking application. REST endpoints can be added later on top of the existing service layer."),
+    servers = @Server(url = "http://localhost:8080", description = "Local server"))
 public class OpenApiConfiguration {}

--- a/src/main/java/com/emt/controller/MatchController.java
+++ b/src/main/java/com/emt/controller/MatchController.java
@@ -2,7 +2,9 @@ package com.emt.controller;
 
 import com.emt.model.request.CreateMatchRequest;
 import com.emt.model.response.MatchResponse;
+import com.emt.model.response.PlayerResponse;
 import com.emt.service.MatchService;
+import com.emt.service.PlayerService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -17,11 +19,20 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 public class MatchController {
 
   private final MatchService matchService;
+  private final PlayerService playerService;
 
   @GetMapping
-  public String getAllMatches(Model model) {
-    List<MatchResponse> matches = matchService.getAllMatches();
+  public String getAllMatches(
+      @RequestParam(required = false) Long playerId,
+      @RequestParam(required = false) Long opponentId,
+      Model model) {
+    List<MatchResponse> matches = matchService.getMatchHistory(playerId, opponentId);
+    List<PlayerResponse> players = playerService.getAllPlayers();
+
     model.addAttribute("matches", matches);
+    model.addAttribute("players", players);
+    model.addAttribute("selectedPlayerId", playerId);
+    model.addAttribute("selectedOpponentId", opponentId);
     return "match-history";
   }
 

--- a/src/main/java/com/emt/repository/MatchRepository.java
+++ b/src/main/java/com/emt/repository/MatchRepository.java
@@ -25,6 +25,31 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
       """
                   SELECT m
                   FROM Match m
+                  JOIN FETCH m.winner
+                  JOIN FETCH m.loser
+                  WHERE m.winner.playerId = :playerId
+                     OR m.loser.playerId = :playerId
+                  ORDER BY m.createdAt DESC
+                  """)
+  List<Match> findMatchesByPlayer(@Param("playerId") Long playerId);
+
+  @Query(
+      """
+                  SELECT m
+                  FROM Match m
+                  JOIN FETCH m.winner
+                  JOIN FETCH m.loser
+                  WHERE (m.winner.playerId = :firstPlayerId AND m.loser.playerId = :secondPlayerId)
+                     OR (m.winner.playerId = :secondPlayerId AND m.loser.playerId = :firstPlayerId)
+                  ORDER BY m.createdAt DESC
+                  """)
+  List<Match> findMatchesBetweenPlayers(
+      @Param("firstPlayerId") Long firstPlayerId, @Param("secondPlayerId") Long secondPlayerId);
+
+  @Query(
+      """
+                  SELECT m
+                  FROM Match m
                   WHERE m.createdAt > :createdAt
                     AND (m.winner.playerId IN (:winnerId, :loserId)
                          OR m.loser.playerId IN (:winnerId, :loserId))

--- a/src/main/java/com/emt/service/MatchService.java
+++ b/src/main/java/com/emt/service/MatchService.java
@@ -31,19 +31,23 @@ public class MatchService {
 
   @Transactional(readOnly = true)
   public List<MatchResponse> getAllMatches() {
-    return mapMatches(matchRepository.findAllWithPlayers());
+    return getMatchHistory(null, null);
   }
 
   @Transactional(readOnly = true)
   public List<MatchResponse> getMatchHistory(Long playerId, Long opponentId) {
+    return mapMatches(findMatchesForHistory(playerId, opponentId));
+  }
+
+  private List<Match> findMatchesForHistory(Long playerId, Long opponentId) {
     if (playerId == null && opponentId == null) {
-      return mapMatches(matchRepository.findAllWithPlayers());
+      return matchRepository.findAllWithPlayers();
     }
     if (playerId == null || opponentId == null || playerId.equals(opponentId)) {
       Long selectedPlayerId = playerId == null ? opponentId : playerId;
-      return mapMatches(matchRepository.findMatchesByPlayer(selectedPlayerId));
+      return matchRepository.findMatchesByPlayer(selectedPlayerId);
     }
-    return mapMatches(matchRepository.findMatchesBetweenPlayers(playerId, opponentId));
+    return matchRepository.findMatchesBetweenPlayers(playerId, opponentId);
   }
 
   @Transactional

--- a/src/main/java/com/emt/service/MatchService.java
+++ b/src/main/java/com/emt/service/MatchService.java
@@ -31,7 +31,19 @@ public class MatchService {
 
   @Transactional(readOnly = true)
   public List<MatchResponse> getAllMatches() {
-    return matchRepository.findAllWithPlayers().stream().map(matchMapper::mapToResponse).toList();
+    return mapMatches(matchRepository.findAllWithPlayers());
+  }
+
+  @Transactional(readOnly = true)
+  public List<MatchResponse> getMatchHistory(Long playerId, Long opponentId) {
+    if (playerId == null && opponentId == null) {
+      return mapMatches(matchRepository.findAllWithPlayers());
+    }
+    if (playerId == null || opponentId == null || playerId.equals(opponentId)) {
+      Long selectedPlayerId = playerId == null ? opponentId : playerId;
+      return mapMatches(matchRepository.findMatchesByPlayer(selectedPlayerId));
+    }
+    return mapMatches(matchRepository.findMatchesBetweenPlayers(playerId, opponentId));
   }
 
   @Transactional
@@ -110,5 +122,9 @@ public class MatchService {
 
       matchRepository.save(match);
     }
+  }
+
+  private List<MatchResponse> mapMatches(List<Match> matches) {
+    return matches.stream().map(matchMapper::mapToResponse).toList();
   }
 }

--- a/src/main/resources/static/styles/styles.css
+++ b/src/main/resources/static/styles/styles.css
@@ -208,6 +208,13 @@ h2 {
     margin-top: 16px;
 }
 
+.filter-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: end;
+}
+
 label {
     color: var(--muted);
     font-weight: 700;
@@ -246,6 +253,23 @@ button:hover {
 }
 
 .button-secondary:hover {
+    border-color: var(--accent);
+    background: var(--surface-muted);
+}
+
+.button-link {
+    display: inline-flex;
+    min-height: 42px;
+    align-items: center;
+    padding: 0 16px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    color: var(--accent-strong);
+    font-weight: 700;
+    text-decoration: none;
+}
+
+.button-link:hover {
     border-color: var(--accent);
     background: var(--surface-muted);
 }
@@ -300,9 +324,11 @@ th {
     }
 
     .form-section form,
+    .filter-form,
     input,
     select,
-    button {
+    button,
+    .button-link {
         width: 100%;
     }
 

--- a/src/main/resources/templates/match-history.html
+++ b/src/main/resources/templates/match-history.html
@@ -33,6 +33,35 @@
 
     <section class="panel">
         <div class="section-title">
+            <h2>Filter history</h2>
+            <span>Pick one player or compare a pair</span>
+        </div>
+        <form class="filter-form" th:action="@{/matches}" method="get">
+            <label for="playerId">Player</label>
+            <select id="playerId" name="playerId">
+                <option value="">All players</option>
+                <option th:each="player : ${players}"
+                        th:value="${player.playerId}"
+                        th:selected="${selectedPlayerId != null && selectedPlayerId == player.playerId}"
+                        th:text="${player.nickname}">Player</option>
+            </select>
+
+            <label for="opponentId">Opponent</label>
+            <select id="opponentId" name="opponentId">
+                <option value="">Any opponent</option>
+                <option th:each="player : ${players}"
+                        th:value="${player.playerId}"
+                        th:selected="${selectedOpponentId != null && selectedOpponentId == player.playerId}"
+                        th:text="${player.nickname}">Opponent</option>
+            </select>
+
+            <button type="submit">Apply filters</button>
+            <a class="button-link" th:href="@{/matches}">Clear</a>
+        </form>
+    </section>
+
+    <section class="panel">
+        <div class="section-title">
             <h2>Reported matches</h2>
             <span th:text="${#lists.size(matches)} + ' matches'">0 matches</span>
         </div>

--- a/src/test/integration/java/com/emt/controller/MatchControllerIT.java
+++ b/src/test/integration/java/com/emt/controller/MatchControllerIT.java
@@ -1,6 +1,7 @@
 package com.emt.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -64,6 +65,7 @@ public class MatchControllerIT extends ITBase {
             .andExpect(status().isOk())
             .andExpect(view().name(MATCH_HISTORY_VIEW))
             .andExpect(model().attribute(SELECTED_PLAYER_ID_ATTRIBUTE, alice.playerId()))
+            .andExpect(model().attribute(SELECTED_OPPONENT_ID_ATTRIBUTE, nullValue()))
             .andExpect(model().attributeExists("players"))
             .andReturn();
 

--- a/src/test/integration/java/com/emt/controller/MatchControllerIT.java
+++ b/src/test/integration/java/com/emt/controller/MatchControllerIT.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.emt.ITBase;
+import com.emt.model.request.CreateMatchRequest;
 import com.emt.model.request.CreatePlayerRequest;
 import com.emt.model.response.MatchResponse;
 import com.emt.model.response.PlayerResponse;
@@ -16,9 +17,18 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 @RequiredArgsConstructor
 public class MatchControllerIT extends ITBase {
+
+  private static final String MATCH_HISTORY_PATH = "/matches";
+  private static final String MATCH_HISTORY_VIEW = "match-history";
+  private static final String MATCHES_ATTRIBUTE = "matches";
+  private static final String OPPONENT_ID_PARAM = "opponentId";
+  private static final String PLAYER_ID_PARAM = "playerId";
+  private static final String SELECTED_OPPONENT_ID_ATTRIBUTE = "selectedOpponentId";
+  private static final String SELECTED_PLAYER_ID_ATTRIBUTE = "selectedPlayerId";
 
   private final MockMvc mockMvc;
   private final PlayerService playerService;
@@ -27,11 +37,86 @@ public class MatchControllerIT extends ITBase {
   @Test
   void getAllMatches_noMatches_expectEmptyList() throws Exception {
     mockMvc
-        .perform(get("/matches"))
+        .perform(get(MATCH_HISTORY_PATH))
         .andExpect(status().isOk())
-        .andExpect(view().name("match-history"))
-        .andExpect(model().attributeExists("matches"))
-        .andExpect(model().attribute("matches", List.of()));
+        .andExpect(view().name(MATCH_HISTORY_VIEW))
+        .andExpect(model().attributeExists(MATCHES_ATTRIBUTE))
+        .andExpect(model().attributeExists("players"))
+        .andExpect(model().attribute(MATCHES_ATTRIBUTE, List.of()));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void getAllMatches_withPlayerFilter_expectOnlyPlayerMatches() throws Exception {
+    PlayerResponse alice = createPlayer("AliceOne");
+    PlayerResponse bob = createPlayer("BobTwo");
+    PlayerResponse carol = createPlayer("CarolThree");
+    MatchResponse aliceVsBob =
+        matchService.createMatch(new CreateMatchRequest(alice.playerId(), bob.playerId()));
+    MatchResponse carolVsAlice =
+        matchService.createMatch(new CreateMatchRequest(carol.playerId(), alice.playerId()));
+    MatchResponse bobVsCarol =
+        matchService.createMatch(new CreateMatchRequest(bob.playerId(), carol.playerId()));
+
+    MvcResult result =
+        mockMvc
+            .perform(get(MATCH_HISTORY_PATH).param(PLAYER_ID_PARAM, String.valueOf(alice.playerId())))
+            .andExpect(status().isOk())
+            .andExpect(view().name(MATCH_HISTORY_VIEW))
+            .andExpect(model().attribute(SELECTED_PLAYER_ID_ATTRIBUTE, alice.playerId()))
+            .andExpect(model().attributeExists("players"))
+            .andReturn();
+
+    List<MatchResponse> matches =
+        (List<MatchResponse>) result.getModelAndView().getModel().get(MATCHES_ATTRIBUTE);
+    assertThat(matches)
+        .extracting(MatchResponse::matchId)
+        .containsExactlyInAnyOrder(aliceVsBob.matchId(), carolVsAlice.matchId())
+        .doesNotContain(bobVsCarol.matchId());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void getAllMatches_withPlayerPairFilter_expectOnlyHeadToHeadMatches() throws Exception {
+    PlayerResponse alice = createPlayer("PairAlice");
+    PlayerResponse bob = createPlayer("PairBob");
+    PlayerResponse carol = createPlayer("PairCarol");
+    MatchResponse aliceVsBob =
+        matchService.createMatch(new CreateMatchRequest(alice.playerId(), bob.playerId()));
+    matchService.createMatch(new CreateMatchRequest(carol.playerId(), alice.playerId()));
+
+    MvcResult result =
+        mockMvc
+            .perform(
+                get(MATCH_HISTORY_PATH)
+                    .param(PLAYER_ID_PARAM, String.valueOf(alice.playerId()))
+                    .param(OPPONENT_ID_PARAM, String.valueOf(bob.playerId())))
+            .andExpect(status().isOk())
+            .andExpect(view().name(MATCH_HISTORY_VIEW))
+            .andExpect(model().attribute(SELECTED_PLAYER_ID_ATTRIBUTE, alice.playerId()))
+            .andExpect(model().attribute(SELECTED_OPPONENT_ID_ATTRIBUTE, bob.playerId()))
+            .andExpect(model().attributeExists("players"))
+            .andReturn();
+
+    List<MatchResponse> matches =
+        (List<MatchResponse>) result.getModelAndView().getModel().get(MATCHES_ATTRIBUTE);
+    assertThat(matches).extracting(MatchResponse::matchId).containsExactly(aliceVsBob.matchId());
+
+    MvcResult reversedResult =
+        mockMvc
+            .perform(
+                get(MATCH_HISTORY_PATH)
+                    .param(PLAYER_ID_PARAM, String.valueOf(bob.playerId()))
+                    .param(OPPONENT_ID_PARAM, String.valueOf(alice.playerId())))
+            .andExpect(status().isOk())
+            .andExpect(view().name(MATCH_HISTORY_VIEW))
+            .andReturn();
+
+    List<MatchResponse> reversedMatches =
+        (List<MatchResponse>) reversedResult.getModelAndView().getModel().get(MATCHES_ATTRIBUTE);
+    assertThat(reversedMatches)
+        .extracting(MatchResponse::matchId)
+        .containsExactly(aliceVsBob.matchId());
   }
 
   @Test
@@ -93,10 +178,14 @@ public class MatchControllerIT extends ITBase {
 
     mockMvc
         .perform(post("/matches/cancel").param("matchId", String.valueOf(matchId)))
-        .andExpect(redirectedUrl("/matches"))
+        .andExpect(redirectedUrl(MATCH_HISTORY_PATH))
         .andExpect(flash().attribute("message", "Match cancelled successfully!"));
 
     List<MatchResponse> updatedMatches = matchService.getAllMatches();
     assertThat(updatedMatches).isEmpty();
+  }
+
+  private PlayerResponse createPlayer(String nickname) {
+    return playerService.createPlayer(CreatePlayerRequest.builder().nickname(nickname).build());
   }
 }

--- a/src/test/unit/java/com/emt/service/MatchServiceTest.java
+++ b/src/test/unit/java/com/emt/service/MatchServiceTest.java
@@ -3,6 +3,7 @@ package com.emt.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -68,7 +69,7 @@ class MatchServiceTest {
 
     assertThat(actualResponses).containsExactly(response);
     verify(matchRepository).findMatchesByPlayer(1L);
-    verify(matchRepository, never()).findMatchesBetweenPlayers(1L, null);
+    verify(matchRepository, never()).findMatchesBetweenPlayers(any(), any());
   }
 
   @Test
@@ -99,7 +100,7 @@ class MatchServiceTest {
 
     assertThat(actualResponses).containsExactly(response);
     verify(matchRepository).findMatchesByPlayer(1L);
-    verify(matchRepository, never()).findMatchesBetweenPlayers(1L, 1L);
+    verify(matchRepository, never()).findMatchesBetweenPlayers(any(), any());
   }
 
   @Test

--- a/src/test/unit/java/com/emt/service/MatchServiceTest.java
+++ b/src/test/unit/java/com/emt/service/MatchServiceTest.java
@@ -3,6 +3,7 @@ package com.emt.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.emt.entity.Match;
@@ -30,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class MatchServiceTest {
 
   private static final BigDecimal CONSTANT_K = new BigDecimal("30");
+  private static final BigDecimal DEFAULT_RATING_CHANGE = new BigDecimal("15.00");
   private static final String WINNER_NAME = "WinnerPlayer";
   private static final String LOSER_NAME = "LoserPlayer";
 
@@ -37,6 +39,83 @@ class MatchServiceTest {
   @Mock private MatchRepository matchRepository;
   @Mock private MatchMapper matchMapper;
   @InjectMocks private MatchService matchService;
+
+  @Test
+  void getMatchHistory_withoutFilters_ShouldReturnAllMatches() {
+    Match match = new Match();
+    MatchResponse response =
+        new MatchResponse(1L, WINNER_NAME, LOSER_NAME, Instant.now(), DEFAULT_RATING_CHANGE);
+
+    given(matchRepository.findAllWithPlayers()).willReturn(List.of(match));
+    given(matchMapper.mapToResponse(match)).willReturn(response);
+
+    List<MatchResponse> actualResponses = matchService.getMatchHistory(null, null);
+
+    assertThat(actualResponses).containsExactly(response);
+    verify(matchRepository).findAllWithPlayers();
+  }
+
+  @Test
+  void getMatchHistory_withSinglePlayerFilter_ShouldReturnPlayerMatches() {
+    Match match = new Match();
+    MatchResponse response =
+        new MatchResponse(1L, WINNER_NAME, LOSER_NAME, Instant.now(), DEFAULT_RATING_CHANGE);
+
+    given(matchRepository.findMatchesByPlayer(1L)).willReturn(List.of(match));
+    given(matchMapper.mapToResponse(match)).willReturn(response);
+
+    List<MatchResponse> actualResponses = matchService.getMatchHistory(1L, null);
+
+    assertThat(actualResponses).containsExactly(response);
+    verify(matchRepository).findMatchesByPlayer(1L);
+    verify(matchRepository, never()).findMatchesBetweenPlayers(1L, null);
+  }
+
+  @Test
+  void getMatchHistory_withOpponentOnlyFilter_ShouldReturnOpponentMatches() {
+    Match match = new Match();
+    MatchResponse response =
+        new MatchResponse(1L, WINNER_NAME, LOSER_NAME, Instant.now(), DEFAULT_RATING_CHANGE);
+
+    given(matchRepository.findMatchesByPlayer(2L)).willReturn(List.of(match));
+    given(matchMapper.mapToResponse(match)).willReturn(response);
+
+    List<MatchResponse> actualResponses = matchService.getMatchHistory(null, 2L);
+
+    assertThat(actualResponses).containsExactly(response);
+    verify(matchRepository).findMatchesByPlayer(2L);
+  }
+
+  @Test
+  void getMatchHistory_withSamePlayerPairFilter_ShouldReturnSinglePlayerMatches() {
+    Match match = new Match();
+    MatchResponse response =
+        new MatchResponse(1L, WINNER_NAME, LOSER_NAME, Instant.now(), DEFAULT_RATING_CHANGE);
+
+    given(matchRepository.findMatchesByPlayer(1L)).willReturn(List.of(match));
+    given(matchMapper.mapToResponse(match)).willReturn(response);
+
+    List<MatchResponse> actualResponses = matchService.getMatchHistory(1L, 1L);
+
+    assertThat(actualResponses).containsExactly(response);
+    verify(matchRepository).findMatchesByPlayer(1L);
+    verify(matchRepository, never()).findMatchesBetweenPlayers(1L, 1L);
+  }
+
+  @Test
+  void getMatchHistory_withPairFilter_ShouldReturnMatchesBetweenPlayers() {
+    Match match = new Match();
+    MatchResponse response =
+        new MatchResponse(1L, WINNER_NAME, LOSER_NAME, Instant.now(), DEFAULT_RATING_CHANGE);
+
+    given(matchRepository.findMatchesBetweenPlayers(1L, 2L)).willReturn(List.of(match));
+    given(matchMapper.mapToResponse(match)).willReturn(response);
+
+    List<MatchResponse> actualResponses = matchService.getMatchHistory(1L, 2L);
+
+    assertThat(actualResponses).containsExactly(response);
+    verify(matchRepository).findMatchesBetweenPlayers(1L, 2L);
+  }
 
   @Test
   void createMatch_WhenWinnerAndLoserAreIdentical_ShouldThrowException() {
@@ -83,7 +162,7 @@ class MatchServiceTest {
     Instant createdAt = Instant.now();
     Player winner = new Player(1L, WINNER_NAME, new BigDecimal("1215.00"), createdAt);
     Player loser = new Player(2L, LOSER_NAME, new BigDecimal("1185.00"), createdAt);
-    Match match = new Match(10L, winner, loser, new BigDecimal("15.00"), createdAt);
+    Match match = new Match(10L, winner, loser, DEFAULT_RATING_CHANGE, createdAt);
 
     given(matchRepository.findById(10L)).willReturn(Optional.of(match));
     given(matchRepository.findMatchesByPlayersAfter(createdAt, 1L, 2L)).willReturn(List.of());
@@ -110,7 +189,7 @@ class MatchServiceTest {
     Instant createdAt = Instant.now();
     Player winner = new Player(1L, WINNER_NAME, new BigDecimal("1215.00"), createdAt);
     Player loser = new Player(2L, LOSER_NAME, new BigDecimal("1185.00"), createdAt);
-    Match match = new Match(20L, winner, loser, new BigDecimal("15.00"), createdAt);
+    Match match = new Match(20L, winner, loser, DEFAULT_RATING_CHANGE, createdAt);
 
     given(playerService.getPlayerById(1L)).willReturn(winner);
     given(playerService.getPlayerById(2L)).willReturn(loser);


### PR DESCRIPTION
## Summary

Adds match history filtering by player and by head-to-head player pair.

## Changes

- Added match history filters for:
  - single player history
  - head-to-head player pairs
  - opponent-only and same-player fallback cases
- Added filter controls to the Match History page
- Added fetch-join repository queries to avoid N+1 loading
- Added unit and integration coverage for filtering behavior
- Added OpenAPI metadata
- Added API and domain behavior documentation
- Updated README and architecture docs

## Verification

- [x] `./gradlew clean check`
- [x] `PATH="/usr/local/bin:/opt/homebrew/bin:$PATH" ./gradlew --no-daemon end2end`
- [x] Runtime smoke check with PostgreSQL
- [x] Verified `/players`, `/matches`, match filters, `/actuator/health`, and `/v3/api-docs`

## Summary by Sourcery

Add match history filtering by player and head-to-head pairs, expose these filters in the UI, and document the application and API behavior with OpenAPI metadata and markdown docs.

New Features:
- Support fetching match history filtered by a single player, an opponent-only player, or a head-to-head player pair.
- Expose match history filters in the match-history UI for selecting player and opponent.

Enhancements:
- Optimize match history queries with fetch joins and reusable mapping logic in the service layer.
- Enrich OpenAPI configuration with project metadata for local discovery.

Documentation:
- Add API and domain behavior documentation covering MVC endpoints, filtering semantics, and rating rules.
- Update architecture and README documentation to reflect match history filtering and new docs entry.

Tests:
- Add unit tests for match history filtering logic in MatchService, including edge cases for various filter combinations.
- Expand integration tests for MatchController to verify filtered views, selected filter state, and empty history behavior.