### PR TITLE
feat: add request header restriction filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The project is intentionally small, but built like a production service: databas
 - Server-rendered UI for player rankings and match history
 - Elo rating calculation with match cancellation, rating rollback, and match history filters
 - JSONB audit revisions for player and match mutations
+- Configurable request blocking by restricted header-value pairs
 - PostgreSQL persistence with Flyway migrations
 - Integration tests backed by Testcontainers
 - Gradle quality gate with JaCoCo coverage verification
@@ -80,7 +81,21 @@ DB_PASSWORD=elt_pass
 DB_SCHEMA=app_elo_match_tracker
 AUDIT_ACTOR_HEADER=X-Actor
 AUDIT_FALLBACK_ACTOR=system
+REQUEST_HEADER_RESTRICTIONS_ENABLED=true
 ```
+
+Header restriction rules are configured as `request-filter.header-restrictions.rules` entries:
+
+```yaml
+request-filter:
+  header-restrictions:
+    enabled: true
+    rules:
+      - header-name: X-Blocked-Client
+        header-value: legacy-importer
+```
+
+Requests containing any configured header-value pair are rejected with `403 Forbidden`.
 
 For production, run with:
 
@@ -145,6 +160,5 @@ The image name is assembled from `repository` and `serviceName` in `gradle.prope
 - Add a separate REST API layer for external clients
 - Add player search and pagination
 - Add match notes and optional game modes
-- Add request filtering by restricted header-value combinations
 - Add tournament management with configurable brackets and game rules
 - Add authentication for administrative actions

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,9 @@ testing {
                 implementation project()
                 implementation 'org.springframework.boot:spring-boot-starter-test'
                 implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+                implementation 'org.springframework:spring-web'
 
+                implementation 'jakarta.servlet:jakarta.servlet-api'
                 implementation 'org.junit.jupiter:junit-jupiter-params:5.10.0'
 
                 implementation 'org.projectlombok:lombok:1.18.32'

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ java {
     }
 }
 
+springBoot {
+    mainClass = 'com.emt.Entrypoint'
+}
+
 jacoco {
     toolVersion = "0.8.12"
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -25,6 +25,29 @@ The `prod` profile disables both OpenAPI docs and Swagger UI. This keeps local d
 | --- | --- | --- |
 | `X-Actor` | No | Optional actor identifier used by auditing. The header name is configurable through `AUDIT_ACTOR_HEADER`. Missing or blank values fall back to `AUDIT_FALLBACK_ACTOR`, which defaults to `system`. |
 
+## Request Filtering
+
+Incoming requests can be rejected before controller handling when they contain a configured restricted header-value pair. The filter is enabled by default, but the default rules list is empty, so local behavior is unchanged until rules are added.
+
+Example configuration:
+
+```yaml
+request-filter:
+  header-restrictions:
+    enabled: true
+    rules:
+      - header-name: X-Blocked-Client
+        header-value: legacy-importer
+```
+
+Filtering semantics:
+
+- any matching rule rejects the request with `403 Forbidden`
+- header names follow servlet container matching behavior
+- header values are matched exactly
+- repeated header values are rejected when any value matches the configured value
+- set `REQUEST_HEADER_RESTRICTIONS_ENABLED=false` to disable the filter without removing rules
+
 ## Player Endpoints
 
 ### `GET /players`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,6 +25,12 @@ Each revision stores the affected entity type, entity id, operation, actor, time
 
 The actor is read from a configurable request header (`AUDIT_ACTOR_HEADER`, default `X-Actor`). Non-web flows fall back to `AUDIT_FALLBACK_ACTOR`.
 
+## Request Filtering
+
+Request header restrictions are enforced by a `OncePerRequestFilter` registered at the highest servlet filter precedence. The filter reads validated `request-filter.header-restrictions` properties and rejects a request with `403 Forbidden` when any configured rule matches a request header name and exact value.
+
+The default rules list is empty, keeping local development open by default while allowing deployments to block known clients, scanners, or integration paths through configuration only. Restricted header values are not written to logs; rejection logs include the URI, method, and matching header name.
+
 ## Persistence
 
 The application uses PostgreSQL with Flyway migrations. Rating values are stored as `NUMERIC(10, 2)` to keep deterministic decimal behavior and avoid floating point drift.

--- a/src/main/java/com/emt/configuration/HeaderRestrictionFilter.java
+++ b/src/main/java/com/emt/configuration/HeaderRestrictionFilter.java
@@ -1,0 +1,47 @@
+package com.emt.configuration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class HeaderRestrictionFilter extends OncePerRequestFilter {
+
+  private static final String REJECTION_MESSAGE = "Request rejected by header restriction policy";
+
+  private final HeaderRestrictionProperties properties;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (rejectRestrictedRequest(request, response)) {
+      return;
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private boolean rejectRestrictedRequest(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    var matchingRule = properties.findMatchingRule(request);
+    if (matchingRule.isEmpty()) {
+      return false;
+    }
+
+    log.warn(
+        "request_rejected_by_header_restriction uri={} method={} header={}",
+        request.getRequestURI(),
+        request.getMethod(),
+        matchingRule.get().getHeaderName());
+    response.sendError(HttpStatus.FORBIDDEN.value(), REJECTION_MESSAGE);
+    return true;
+  }
+}

--- a/src/main/java/com/emt/configuration/HeaderRestrictionProperties.java
+++ b/src/main/java/com/emt/configuration/HeaderRestrictionProperties.java
@@ -1,0 +1,51 @@
+package com.emt.configuration;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "request-filter.header-restrictions")
+public class HeaderRestrictionProperties {
+
+  @Valid private List<Rule> rules = new ArrayList<>();
+
+  private boolean enabled = true;
+
+  public Optional<Rule> findMatchingRule(HttpServletRequest request) {
+    if (!enabled || rules.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return rules.stream().filter(rule -> rule.matches(request)).findFirst();
+  }
+
+  @Getter
+  @Setter
+  public static class Rule {
+
+    @NotBlank private String headerName;
+
+    @NotBlank private String headerValue;
+
+    boolean matches(HttpServletRequest request) {
+      Enumeration<String> headerValues = request.getHeaders(headerName);
+      while (headerValues.hasMoreElements()) {
+        if (headerValue.equals(headerValues.nextElement())) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+}

--- a/src/main/java/com/emt/configuration/RequestFilteringConfiguration.java
+++ b/src/main/java/com/emt/configuration/RequestFilteringConfiguration.java
@@ -1,0 +1,23 @@
+package com.emt.configuration;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+@EnableConfigurationProperties(HeaderRestrictionProperties.class)
+public class RequestFilteringConfiguration {
+
+  @Bean
+  public FilterRegistrationBean<HeaderRestrictionFilter> headerRestrictionFilter(
+      HeaderRestrictionProperties properties) {
+    FilterRegistrationBean<HeaderRestrictionFilter> registration = new FilterRegistrationBean<>();
+    registration.setFilter(new HeaderRestrictionFilter(properties));
+    registration.setName("headerRestrictionFilter");
+    registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    registration.addUrlPatterns("/*");
+    return registration;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,11 @@ audit:
   actor-header: ${AUDIT_ACTOR_HEADER:X-Actor}
   fallback-actor: ${AUDIT_FALLBACK_ACTOR:system}
 
+request-filter:
+  header-restrictions:
+    enabled: ${REQUEST_HEADER_RESTRICTIONS_ENABLED:true}
+    rules: []
+
 spring:
   application:
     name: elo_match_tracker

--- a/src/test/unit/java/com/emt/configuration/HeaderRestrictionFilterTest.java
+++ b/src/test/unit/java/com/emt/configuration/HeaderRestrictionFilterTest.java
@@ -33,6 +33,23 @@ class HeaderRestrictionFilterTest {
   }
 
   @Test
+  void doFilterInternal_withEmptyRules_shouldDelegateToFilterChainAndLeaveResponseUnchanged()
+      throws Exception {
+    HeaderRestrictionProperties properties = new HeaderRestrictionProperties();
+    properties.setEnabled(true);
+    HeaderRestrictionFilter filter = new HeaderRestrictionFilter(properties);
+    MockHttpServletRequest request = request();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    TrackingFilterChain filterChain = new TrackingFilterChain();
+    response.setStatus(HttpStatus.OK.value());
+
+    filter.doFilter(request, response, filterChain);
+
+    assertThat(filterChain.invoked).isTrue();
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+  }
+
+  @Test
   void doFilterInternal_withDifferentHeaderValue_shouldContinueRequest() throws Exception {
     HeaderRestrictionFilter filter = new HeaderRestrictionFilter(restrictionsEnabled());
     MockHttpServletRequest request = request();

--- a/src/test/unit/java/com/emt/configuration/HeaderRestrictionFilterTest.java
+++ b/src/test/unit/java/com/emt/configuration/HeaderRestrictionFilterTest.java
@@ -1,0 +1,127 @@
+package com.emt.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class HeaderRestrictionFilterTest {
+
+  private static final String RESTRICTED_HEADER = "X-Blocked-Client";
+  private static final String RESTRICTED_VALUE = "legacy-importer";
+  private static final String REQUEST_METHOD = "GET";
+  private static final String REQUEST_PATH = "/players";
+
+  @Test
+  void doFilterInternal_withConfiguredHeaderValuePair_shouldRejectRequest() throws Exception {
+    HeaderRestrictionFilter filter = new HeaderRestrictionFilter(restrictionsEnabled());
+    MockHttpServletRequest request = request();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = (request1, response1) -> {};
+    request.addHeader(RESTRICTED_HEADER, RESTRICTED_VALUE);
+
+    filter.doFilter(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    assertThat(response.getErrorMessage()).isEqualTo("Request rejected by header restriction policy");
+  }
+
+  @Test
+  void doFilterInternal_withDifferentHeaderValue_shouldContinueRequest() throws Exception {
+    HeaderRestrictionFilter filter = new HeaderRestrictionFilter(restrictionsEnabled());
+    MockHttpServletRequest request = request();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    TrackingFilterChain filterChain = new TrackingFilterChain();
+    request.addHeader(RESTRICTED_HEADER, "trusted-client");
+
+    filter.doFilter(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(filterChain.invoked).isTrue();
+  }
+
+  @Test
+  void doFilterInternal_whenRestrictionsDisabled_shouldContinueRequest() throws Exception {
+    HeaderRestrictionProperties properties = restrictionsEnabled();
+    properties.setEnabled(false);
+    HeaderRestrictionFilter filter = new HeaderRestrictionFilter(properties);
+    MockHttpServletRequest request = request();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    TrackingFilterChain filterChain = new TrackingFilterChain();
+    request.addHeader(RESTRICTED_HEADER, RESTRICTED_VALUE);
+
+    filter.doFilter(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(filterChain.invoked).isTrue();
+  }
+
+  @Test
+  void doFilterInternal_withRepeatedHeaderValues_shouldRejectWhenAnyValueMatches()
+      throws Exception {
+    HeaderRestrictionFilter filter = new HeaderRestrictionFilter(restrictionsEnabled());
+    MockHttpServletRequest request = request();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = (request1, response1) -> {};
+    request.addHeader(RESTRICTED_HEADER, "trusted-client");
+    request.addHeader(RESTRICTED_HEADER, RESTRICTED_VALUE);
+
+    filter.doFilter(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+  }
+
+  @Test
+  void doFilterInternal_withoutMatchingRule_shouldDelegateToFilterChain() throws Exception {
+    HeaderRestrictionFilter filter = new HeaderRestrictionFilter(restrictionsEnabled());
+    MockHttpServletRequest request = request();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = org.mockito.Mockito.mock(FilterChain.class);
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void doFilterInternal_withRestrictedRequest_shouldNotDelegateToFilterChain() throws Exception {
+    HeaderRestrictionFilter filter = new HeaderRestrictionFilter(restrictionsEnabled());
+    MockHttpServletRequest request = request();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = org.mockito.Mockito.mock(FilterChain.class);
+    request.addHeader(RESTRICTED_HEADER, RESTRICTED_VALUE);
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(filterChain, never()).doFilter(request, response);
+  }
+
+  private HeaderRestrictionProperties restrictionsEnabled() {
+    HeaderRestrictionProperties properties = new HeaderRestrictionProperties();
+    HeaderRestrictionProperties.Rule rule = new HeaderRestrictionProperties.Rule();
+    rule.setHeaderName(RESTRICTED_HEADER);
+    rule.setHeaderValue(RESTRICTED_VALUE);
+    properties.setRules(List.of(rule));
+    return properties;
+  }
+
+  private MockHttpServletRequest request() {
+    return new MockHttpServletRequest(REQUEST_METHOD, REQUEST_PATH);
+  }
+
+  private static class TrackingFilterChain implements FilterChain {
+
+    private boolean invoked;
+
+    @Override
+    public void doFilter(jakarta.servlet.ServletRequest request, jakarta.servlet.ServletResponse response) {
+      invoked = true;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds configurable filtering for restricted request header/value pairs. Matching requests are rejected with `403 Forbidden`; the default config keeps the behavior unchanged with an empty rules list.

## Summary by Sourcery

Add a configurable servlet filter that blocks HTTP requests based on restricted header-value pairs and updates configuration, documentation, and tests to support this behavior.

New Features:
- Introduce configurable header restriction properties that define enabled state and a list of restricted header-value rules.
- Register a high-precedence servlet filter that rejects requests with matching restricted header-value pairs using HTTP 403.

Enhancements:
- Document the request header restriction mechanism and configuration in the architecture and API docs, and surface the feature in the README overview.
- Set the Spring Boot main class explicitly in the Gradle build configuration and add required web/servlet dependencies for the new filter.

Documentation:
- Describe request filtering configuration and semantics in API and architecture documentation and update the README to explain header restriction rules and usage.

Tests:
- Add unit tests covering header restriction matching, repeated header values, disabled behavior, and filter chain delegation behavior.