### PR TITLE
feat: add tournament management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Elo Match Tracker
 
-Elo Match Tracker is a Java 17 Spring Boot application for tracking 1v1 matches and keeping player ratings consistent with the Elo ranking system.
+Elo Match Tracker is a small Spring Boot project for registering players, reporting 1v1 match results,
+and keeping player ratings updated with the Elo formula.
 
-The project is intentionally small, but built like a production service: database migrations, layered tests, Testcontainers integration checks, container image support, health endpoints, and a 70% JaCoCo coverage gate.
+I built it as an MVC application first, so the main interface is server-rendered with Thymeleaf.
+The service layer is separated from controllers, so adding a REST API later should not require rewriting the core logic.
 
-## Highlights
+## What The App Does
 
-- Server-rendered UI for player rankings and match history
-- Elo rating calculation with match cancellation, rating rollback, and match history filters
-- JSONB audit revisions for player and match mutations
-- Configurable request blocking by restricted header-value pairs
-- PostgreSQL persistence with Flyway migrations
-- Integration tests backed by Testcontainers
-- Gradle quality gate with JaCoCo coverage verification
-- Docker Compose setup for local development
-- Production profile with restricted actuator and disabled Swagger UI
+- Register players with an initial Elo rating of `1200`.
+- Report match results and update both players in one transaction.
+- Cancel matches and repair later rating history.
+- Filter match history by one player or by a pair of players.
+- Create tournament setups with roster size, seeding mode, game format, scoring, and bracket type.
+- Store audit revisions for player and match changes.
+- Optionally block requests by configured header-value pairs.
 
 ## Tech Stack
 
@@ -26,23 +26,24 @@ The project is intentionally small, but built like a production service: databas
 - Flyway
 - Gradle
 - JUnit 5, Mockito, AssertJ, Testcontainers
-- Jib for container image builds
+- JaCoCo, Checkstyle, PMD
+- Jib for Docker image builds
 
 ## Project Structure
 
 ```text
 src/main/java/com/emt
-├── configuration   # MVC exception handling and OpenAPI configuration
-├── audit           # entity mutation audit listener and actor resolution
-├── controller      # UI endpoints
+├── audit           # Hibernate audit listener and actor resolution
+├── configuration   # MVC errors, OpenAPI, request filtering
+├── controller      # Thymeleaf MVC endpoints
 ├── entity          # JPA entities
-├── mapper          # entity/DTO mapping
-├── model           # requests, responses, exceptions
+├── mapper          # entity/request/response mapping
+├── model           # requests, responses, enums, exceptions
 ├── repository      # Spring Data repositories
-└── service         # business logic and Elo rating updates
+└── service         # business rules and transactions
 ```
 
-## Getting Started
+## Run Locally
 
 Start PostgreSQL:
 
@@ -56,21 +57,26 @@ Run the application:
 ./gradlew bootRun
 ```
 
-Open the UI:
+Open the app:
 
 ```text
 http://localhost:8080/players
 ```
 
-Swagger UI is available locally at:
+Useful local links:
 
 ```text
+http://localhost:8080/matches
+http://localhost:8080/tournaments
 http://localhost:8080/swagger-ui.html
+http://localhost:9090/actuator/health
 ```
 
 ## Configuration
 
-The application reads database settings from environment variables with local defaults:
+Local defaults are defined in `src/main/resources/application.yml`.
+
+Common environment variables:
 
 ```text
 DB_HOST=localhost
@@ -84,7 +90,9 @@ AUDIT_FALLBACK_ACTOR=system
 REQUEST_HEADER_RESTRICTIONS_ENABLED=true
 ```
 
-Header restriction rules are configured as `request-filter.header-restrictions.rules` entries:
+The request filter is enabled by default, but there are no blocked headers configured locally.
+
+Example blocked header rule:
 
 ```yaml
 request-filter:
@@ -95,17 +103,15 @@ request-filter:
         header-value: legacy-importer
 ```
 
-Requests containing any configured header-value pair are rejected with `403 Forbidden`.
-
-For production, run with:
+Run with the production profile:
 
 ```bash
 SPRING_PROFILES_ACTIVE=prod ./gradlew bootRun
 ```
 
-The production profile disables Swagger UI and keeps actuator exposure limited to health and info endpoints.
+The production profile disables Swagger UI and keeps actuator exposure limited.
 
-## Tests
+## Tests And Quality Gate
 
 Run unit tests:
 
@@ -119,37 +125,44 @@ Run integration tests:
 ./gradlew integration
 ```
 
-Run the quality gate:
+Run the full quality gate:
 
 ```bash
 ./gradlew check
 ```
 
-The quality gate verifies unit tests and enforces at least 70% JaCoCo instruction coverage.
+Run end-to-end tests:
+
+```bash
+./gradlew end2end
+```
+
+The `check` task includes Checkstyle, PMD, tests, and a JaCoCo coverage rule with a minimum of 70% instruction coverage.
 
 ## Database
 
-Flyway migrations live in:
+Flyway migrations are in:
 
 ```text
 src/main/resources/db/migration
 ```
 
-Current migrations create player, match, and audit revision tables, store Elo rating deltas for match cancellation, and add indexes for match history and audit lookups.
+The schema currently includes players, matches, audit revisions, tournaments, and tournament participants.
+Rating changes are stored on matches so cancellation can repair Elo history later.
 
-## Container Image
+## Docker Image
 
-Build a local Docker image with Jib:
+Build a local image with Jib:
 
 ```bash
 ./gradlew jibDockerBuild
 ```
 
-The image name is assembled from `repository` and `serviceName` in `gradle.properties`.
+The image name comes from `repository` and `serviceName` in `gradle.properties`.
 
 ## Documentation
 
-- [API and Domain Behavior](docs/API.md)
+- [API and Domain Notes](docs/API.md)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Contributing](CONTRIBUTING.md)
 - [Security](SECURITY.md)
@@ -157,8 +170,8 @@ The image name is assembled from `repository` and `serviceName` in `gradle.prope
 
 ## Roadmap
 
-- Add a separate REST API layer for external clients
-- Add player search and pagination
-- Add match notes and optional game modes
-- Add tournament management with configurable brackets and game rules
-- Add authentication for administrative actions
+- Add a separate JSON REST API for external clients.
+- Add player search and pagination.
+- Add match notes and optional game modes.
+- Add tournament result tracking and bracket progression.
+- Add authentication for admin actions.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,35 +1,33 @@
-# API and Domain Behavior
+# API and Domain Notes
 
-Elo Match Tracker currently exposes a server-rendered MVC interface. The endpoints below return HTML views or redirects rather than JSON response bodies. This keeps the UI simple today while leaving the service layer ready for a dedicated REST API in the future.
+The app currently uses Spring MVC and Thymeleaf. Most endpoints return HTML pages or redirects, not JSON responses.
 
-## Base URLs
+OpenAPI is enabled only as a local helper. Since there are no REST controllers yet, `/v3/api-docs` mainly shows project metadata.
+The actual MVC behavior is documented here.
 
-- Application UI: `http://localhost:8080`
-- Management server: `http://localhost:9090`
-- Swagger UI in local profile: `http://localhost:8080/swagger-ui.html`
+## Local URLs
 
-## OpenAPI and Swagger
+| Page | URL |
+| --- | --- |
+| Players | `http://localhost:8080/players` |
+| Match history | `http://localhost:8080/matches` |
+| Tournaments | `http://localhost:8080/tournaments` |
+| Swagger UI | `http://localhost:8080/swagger-ui.html` |
+| Health | `http://localhost:9090/actuator/health` |
 
-OpenAPI documentation is enabled for local development:
-
-- OpenAPI JSON: `GET /v3/api-docs`
-- Swagger UI: `GET /swagger-ui.html`
-
-Because the current application is server-rendered MVC, the generated OpenAPI document is mainly a local discovery placeholder with project metadata. The MVC routes are documented manually in this file. A future REST layer should expose JSON endpoints through `@RestController` and become the primary OpenAPI contract.
-
-The `prod` profile disables both OpenAPI docs and Swagger UI. This keeps local discovery convenient while avoiding public API documentation exposure in production.
-
-## Request Headers
+## Headers
 
 | Header | Required | Description |
 | --- | --- | --- |
-| `X-Actor` | No | Optional actor identifier used by auditing. The header name is configurable through `AUDIT_ACTOR_HEADER`. Missing or blank values fall back to `AUDIT_FALLBACK_ACTOR`, which defaults to `system`. |
+| `X-Actor` | No | Used by auditing. If it is missing, the app uses the configured fallback actor, currently `system`. |
 
-## Request Filtering
+The header name can be changed with `AUDIT_ACTOR_HEADER`.
 
-Incoming requests can be rejected before controller handling when they contain a configured restricted header-value pair. The filter is enabled by default, but the default rules list is empty, so local behavior is unchanged until rules are added.
+## Request Blocking
 
-Example configuration:
+The app can reject requests when a configured header-value pair is present.
+
+Example:
 
 ```yaml
 request-filter:
@@ -40,86 +38,64 @@ request-filter:
         header-value: legacy-importer
 ```
 
-Filtering semantics:
+Behavior:
 
-- any matching rule rejects the request with `403 Forbidden`
-- header names follow servlet container matching behavior
+- matching requests return `403 Forbidden`
 - header values are matched exactly
-- repeated header values are rejected when any value matches the configured value
-- set `REQUEST_HEADER_RESTRICTIONS_ENABLED=false` to disable the filter without removing rules
+- if a request has repeated header values, any matching value is enough to block it
+- local config has an empty rules list, so nothing is blocked by default
 
-## Player Endpoints
+## Players
 
 ### `GET /players`
 
-Renders the leaderboard page.
+Shows the leaderboard page.
 
-The page includes:
-
-- all registered players sorted by Elo rating descending
-- the player registration form
-- the match reporting form
-
-Successful response:
-
-- Status: `200 OK`
-- View: `elo-ranking`
+The model contains registered players sorted by Elo rating, the player registration form, and the match reporting form.
 
 ### `POST /players/register`
 
-Registers a new player.
+Creates a player.
 
-Form parameters:
+Form fields:
 
-| Name | Required | Description |
+| Name | Required | Notes |
 | --- | --- | --- |
-| `nickname` | Yes | Unique player nickname. Must satisfy the validation constraints from `CreatePlayerRequest`. |
+| `nickname` | Yes | Must be unique. Validation rules are defined in `CreatePlayerRequest`. |
 
-Successful response:
+Success:
 
-- Status: `3xx redirect`
-- Redirect: `/players`
-- Flash message: `Player added successfully!`
-
-Error behavior:
-
-- duplicate nickname redirects back with an error flash message
-- validation errors redirect back with field-level flash errors
+- redirects to `/players`
+- shows `Player added successfully!`
 
 Example:
 
 ```bash
 curl -i -X POST \
-  -H 'X-Actor: portfolio-demo' \
+  -H 'X-Actor: demo-user' \
   -d 'nickname=Alice' \
   http://localhost:8080/players/register
 ```
 
-## Match Endpoints
+## Matches
 
 ### `GET /matches`
 
-Renders the match history page.
+Shows match history.
 
-Query parameters:
+Query params:
 
-| Name | Required | Description |
+| Name | Required | Notes |
 | --- | --- | --- |
-| `playerId` | No | Filters history to matches where the selected player was either winner or loser. |
-| `opponentId` | No | When used with `playerId`, filters to head-to-head matches between both players. When used alone, behaves like a single-player filter. |
+| `playerId` | No | Shows matches where this player is winner or loser. |
+| `opponentId` | No | With `playerId`, shows head-to-head matches. Alone, it behaves like a single-player filter. |
 
-Filtering semantics:
+Filter behavior:
 
-- no filters: show all matches
-- only `playerId`: show all matches involving that player
-- only `opponentId`: show all matches involving that player
-- both ids and different values: show head-to-head matches in either winner/loser direction
-- both ids and the same value: show that player's full match history
-
-Successful response:
-
-- Status: `200 OK`
-- View: `match-history`
+- no params: all matches
+- only one id: all matches for that player
+- two different ids: matches between those two players in either direction
+- same id twice: full history for that player
 
 Examples:
 
@@ -131,26 +107,19 @@ curl -i 'http://localhost:8080/matches?playerId=1&opponentId=2'
 
 ### `POST /matches/report`
 
-Reports a match result and updates both players' Elo ratings in one transaction.
+Reports a match and updates Elo ratings in one transaction.
 
-Form parameters:
+Form fields:
 
-| Name | Required | Description |
+| Name | Required | Notes |
 | --- | --- | --- |
-| `winnerId` | Yes | Player id of the match winner. |
-| `loserId` | Yes | Player id of the match loser. |
+| `winnerId` | Yes | Match winner. |
+| `loserId` | Yes | Match loser. Must be different from winner. |
 
-Successful response:
+Success:
 
-- Status: `3xx redirect`
-- Redirect: `/players`
-- Flash message: `Match reported successfully!`
-
-Error behavior:
-
-- identical winner and loser ids are rejected
-- unknown player ids redirect back with an error flash message
-- validation errors redirect back with field-level flash errors
+- redirects to `/players`
+- shows `Match reported successfully!`
 
 Example:
 
@@ -163,129 +132,128 @@ curl -i -X POST \
 
 ### `POST /matches/cancel`
 
-Cancels a recorded match and repairs affected Elo ratings.
+Cancels a match and repairs affected ratings.
 
-Form parameters:
+Form fields:
 
-| Name | Required | Description |
+| Name | Required | Notes |
 | --- | --- | --- |
-| `matchId` | Yes | Match id to cancel. |
+| `matchId` | Yes | Existing match id. |
 
-Successful response:
+Success:
 
-- Status: `3xx redirect`
-- Redirect: `/matches`
-- Flash message: `Match cancelled successfully!`
+- redirects to `/matches`
+- shows `Match cancelled successfully!`
 
-Error behavior:
+## Tournaments
 
-- unknown match ids redirect back with an error flash message
+### `GET /tournaments`
+
+Shows the tournament setup page.
+
+The page contains:
+
+- tournament creation form
+- player list for seeding
+- existing tournament setups with seed order
+
+### `POST /tournaments`
+
+Creates a tournament setup.
+
+Form fields:
+
+| Name | Required | Notes |
+| --- | --- | --- |
+| `name` | Yes | Tournament name. |
+| `playerCount` | Yes | Supported values: `2`, `4`, `8`, `16`. |
+| `seedingMode` | Yes | `MANUAL` or `RANDOM`. |
+| `gameFormat` | Yes | `BO1`, `BO3`, or `BO5`. |
+| `winningPoints` | Yes | Positive value, for example `11` or `21`. |
+| `bracketType` | Yes | `SINGLE_ELIMINATION` or `ROUND_ROBIN`. |
+| `playerIds` | Yes | Exactly `playerCount` unique ids. Repeated params preserve order for manual seeding. |
+
+Success:
+
+- redirects to `/tournaments`
+- shows `Tournament created successfully!`
 
 Example:
 
 ```bash
 curl -i -X POST \
-  -H 'X-Actor: admin-user' \
-  -d 'matchId=42' \
-  http://localhost:8080/matches/cancel
+  -d 'name=Friday Finals' \
+  -d 'playerCount=2' \
+  -d 'seedingMode=MANUAL' \
+  -d 'gameFormat=BO3' \
+  -d 'winningPoints=11' \
+  -d 'bracketType=SINGLE_ELIMINATION' \
+  -d 'playerIds=1' \
+  -d 'playerIds=2' \
+  http://localhost:8080/tournaments
 ```
 
-## Management Endpoints
+Current limitation: tournaments store setup and participants only.
+Match generation, results, and bracket progression are planned separately.
 
-### `GET /actuator/health`
+## Elo Rules
 
-Returns application health from the management server.
+Every new player starts with rating `1200`.
 
-Successful response:
-
-- Status: `200 OK`
-- Body includes status such as `UP`
-
-Example:
-
-```bash
-curl -i http://localhost:9090/actuator/health
-```
-
-## Elo Rating Model
-
-Every player starts with an Elo rating of `1200`.
-
-When a match is reported, the service calculates the winner's expected score using the standard Elo probability formula:
+Expected winner score:
 
 ```text
 expectedWinner = 1 / (1 + 10 ^ ((loserRating - winnerRating) / 400))
 ```
 
-The project uses a constant K-factor of `30`:
+The app uses K-factor `30`:
 
 ```text
 winnerRatingChange = 30 * (1 - expectedWinner)
 loserRatingChange = -winnerRatingChange
 ```
 
-Then both ratings are updated in the same transaction:
+Ratings are stored as `NUMERIC(10, 2)` in PostgreSQL. This avoids floating point issues and keeps values readable.
 
-```text
-winner.rating = winner.rating + winnerRatingChange
-loser.rating = loser.rating - winnerRatingChange
-```
+## Match Cancellation
 
-Rating values are persisted as `NUMERIC(10, 2)` in PostgreSQL to avoid floating-point drift.
+Elo is order-sensitive, so cancelling an old match is not just deleting a row.
 
-## Match Cancellation and Rating Repair
+The service:
 
-A match cancellation is treated as a data correction rather than a simple delete.
+1. Loads the cancelled match.
+2. Reverts its rating delta for both players.
+3. Recalculates later matches involving either affected player.
+4. Deletes the cancelled match.
 
-The cancellation flow does three things:
+This keeps the current leaderboard consistent with visible match history.
 
-1. Loads the match being cancelled.
-2. Reverts the stored rating delta for the winner and loser.
-3. Recalculates later matches involving either affected player, then deletes the cancelled match.
+## Auditing
 
-This matters because Elo is order-sensitive. Removing an old result can change the rating context for later matches, so the service repairs the downstream rating history instead of only deleting one row.
+Player and match changes are audited with Hibernate event listeners.
 
-## Match History Filtering
-
-Match history queries use fetch joins for `winner` and `loser` to keep the rendered page from triggering N+1 lazy loading.
-
-The head-to-head filter is direction-agnostic. A request for `playerId=1&opponentId=2` returns both:
-
-- matches where player `1` beat player `2`
-- matches where player `2` beat player `1`
-
-## Auditing Behavior
-
-Mutations for `Player` and `Match` are audited through Hibernate event listeners.
-
-Each audit revision stores:
+Each audit row stores:
 
 - entity name
 - entity id
-- operation (`INSERT`, `UPDATE`, `DELETE`)
-- JSONB snapshot of entity state
-- actor from the configured request header
+- operation: `INSERT`, `UPDATE`, or `DELETE`
+- JSONB snapshot
+- actor from request header
 - timestamp with time zone
 
-Audit writes participate in the same transactional flow as the entity mutation. Match snapshots store player references as ids instead of nested entity graphs, keeping audit payloads compact and stable.
+Tournament setup is not audited yet because the current audit feature was scoped to players and matches.
 
 ## Error Handling
 
-The current MVC controllers use redirect-based error handling:
+This is an MVC app, so errors usually redirect back to a page with flash messages.
 
-- validation errors are stored as flash attributes
-- domain exceptions are shown as flash error messages
-- `/matches/report` errors redirect to `/players`
-- other `/matches` errors redirect to `/matches`
-- player errors redirect to `/players`
+Redirect targets:
 
-Because this is currently an MVC-first application, clients should not expect JSON error payloads from these endpoints.
+| Error area | Redirect |
+| --- | --- |
+| Players | `/players` |
+| Match reporting | `/players` |
+| Match history or cancellation | `/matches` |
+| Tournaments | `/tournaments` |
 
-## Future REST API Notes
-
-The service and repository layers are intentionally separated from MVC controllers. A future REST API can reuse the same business logic while adding:
-
-- JSON request and response models
-- explicit HTTP status codes for domain errors
-- pagination for player and match history queries
-- authentication and authorization controls
+Clients should not expect JSON error bodies from these MVC endpoints.

--- a/docs/API.md
+++ b/docs/API.md
@@ -193,12 +193,15 @@ curl -i -X POST \
   http://localhost:8080/tournaments
 ```
 
+Manual seeding keeps the submitted player order.
+Random seeding is intentionally non-deterministic; once saved, seed numbers are the source of truth.
+
 Current limitation: tournaments store setup and participants only.
 Match generation, results, and bracket progression are planned separately.
 
 ## Elo Rules
 
-Every new player starts with rating `1200`.
+Every new player starts with a rating of `1200`.
 
 Expected winner score:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,55 +1,114 @@
 # Architecture
 
-Elo Match Tracker is a layered Spring Boot application. The current interface is server-rendered MVC, while the core business logic is kept in services so a REST API can be added later without rewriting the domain flow.
+This project is built as a small layered Spring Boot application.
+The UI is MVC/Thymeleaf, but the domain logic is kept in services so it can be reused if a REST API is added later.
 
-## Main Flow
+## Layers
 
-1. A player is registered through `PlayerController`.
-2. `PlayerService` validates nickname uniqueness and persists the player.
-3. A match is reported through `MatchController`.
-4. `MatchService` loads both players, calculates the Elo delta, updates both ratings, and saves the match in one transaction.
-5. Match history is read with fetch joins to avoid lazy-loading each player row individually.
-6. Match history can be filtered by one player or by a head-to-head pair through query parameters.
+| Layer | Responsibility |
+| --- | --- |
+| Controller | Handles web requests, prepares model attributes, returns views or redirects. |
+| Service | Contains business rules and transaction boundaries. |
+| Mapper | Converts between entities, requests, and response models. |
+| Repository | Reads and writes database rows through Spring Data JPA. |
+| Entity | Represents persisted data and relationships. |
+
+## Player Flow
+
+1. `PlayerController` receives the registration form.
+2. `PlayerService` checks nickname uniqueness.
+3. `PlayerMapper` creates the entity.
+4. `PlayerRepository` saves it.
+5. The controller redirects back to `/players`.
+
+Players start with rating `1200`.
+
+## Match Flow
+
+1. `MatchController` receives winner and loser ids.
+2. `MatchService` checks that both ids are different.
+3. The service loads both players.
+4. Elo rating changes are calculated.
+5. Both player ratings and the match row are saved in one transaction.
+6. The controller redirects back to the leaderboard.
+
+Match history queries use fetch joins for winner and loser. This avoids N+1 queries when rendering the history page.
 
 ## Match Cancellation
 
-Cancelling a match is treated as a data correction. The service reverses the cancelled match rating delta, recalculates later matches involving either player, updates stored deltas, and removes the cancelled match.
+Cancelling a match is handled as a data correction.
 
-This keeps current player ratings consistent with the visible match history.
+The service reverts the cancelled match delta, recalculates later matches for the affected players,
+updates stored deltas, and removes the cancelled match.
+This is more work than a delete, but it keeps Elo ratings correct because Elo depends on match order.
+
+## Tournament Setup
+
+Tournaments follow the same structure as players and matches.
+
+`TournamentController` renders the page and submits create requests.
+`TournamentService` validates the roster and applies seeding rules.
+`TournamentMapper` builds the `Tournament` entity and maps saved tournaments back to response models.
+
+Validation rules:
+
+- player count must be one of `2`, `4`, `8`, or `16`
+- selected players must not be empty
+- selected players must be unique
+- selected roster size must match `playerCount`
+
+Manual seeding keeps the submitted player order.
+Random seeding shuffles the selected players before assigning seed numbers.
+
+The current feature stores setup data only.
+Tournament match generation and bracket progression are future work.
 
 ## Auditing
 
-Player and match inserts, updates, and deletes are audited through Hibernate event listeners instead of ad-hoc service calls. That keeps audit behavior close to persistence and makes it harder for future features to accidentally bypass it.
+Player and match inserts, updates, and deletes are audited through Hibernate event listeners.
 
-Each revision stores the affected entity type, entity id, operation, actor, timestamp, and a JSONB snapshot of the entity state. Player references inside match snapshots are stored as ids, not nested entity graphs, so the audit payload remains small and stable.
+The audit listener writes a separate `audit_revision` row with entity name, entity id, operation, actor, timestamp, and a JSONB snapshot.
+For matches, player references are stored as ids instead of nested objects to keep snapshots stable.
 
-The actor is read from a configurable request header (`AUDIT_ACTOR_HEADER`, default `X-Actor`). Non-web flows fall back to `AUDIT_FALLBACK_ACTOR`.
+The actor comes from the configured request header, currently `X-Actor`. If the header is missing, the fallback actor is used.
 
 ## Request Filtering
 
-Request header restrictions are enforced by a `OncePerRequestFilter` registered at the highest servlet filter precedence. The filter reads validated `request-filter.header-restrictions` properties and rejects a request with `403 Forbidden` when any configured rule matches a request header name and exact value.
+`HeaderRestrictionFilter` runs before controllers.
+It checks configured header-value rules and rejects matching requests with `403 Forbidden`.
 
-The default rules list is empty, keeping local development open by default while allowing deployments to block known clients, scanners, or integration paths through configuration only. Restricted header values are not written to logs; rejection logs include the URI, method, and matching header name.
+The rules list is empty by default, which keeps local development simple.
+Deployments can add rules through configuration without changing Java code.
 
 ## Persistence
 
-The application uses PostgreSQL with Flyway migrations. Rating values are stored as `NUMERIC(10, 2)` to keep deterministic decimal behavior and avoid floating point drift.
+The app uses PostgreSQL and Flyway.
 
-Indexes exist for the match fields used by history and recalculation queries:
+Important database choices:
 
-- `winner_id`
-- `loser_id`
-- `created_at`
-
-Audit revisions are indexed by entity, operation, and creation time to support timeline and troubleshooting queries.
+- ratings use `NUMERIC(10, 2)` instead of floating point numbers
+- match history fields are indexed for filtering and recalculation
+- audit revisions are indexed for lookup by entity, operation, and creation time
+- tournament participants have unique constraints for player membership and seed number per tournament
 
 ## Profiles
 
-The default profile is optimized for local development. The `prod` profile disables Swagger UI and keeps actuator exposure limited.
+The default profile is for local development.
+
+The `prod` profile disables Swagger UI and keeps actuator exposure limited.
+This is safer for a deployed environment while still allowing local API discovery during development.
 
 ## Testing Strategy
 
-- Unit tests cover service behavior and Elo calculations.
-- Integration tests use Testcontainers PostgreSQL for controller and service flows.
-- End-to-end tests exercise the containerized application stack.
-- JaCoCo enforces a minimum 70% unit-test coverage gate.
+The project has several test layers:
+
+- unit tests for service behavior and small components
+- integration tests with Testcontainers PostgreSQL
+- end-to-end tests for the containerized app stack
+- JaCoCo coverage verification with a 70% minimum instruction coverage rule
+
+The usual command before opening a PR is:
+
+```bash
+./gradlew clean check
+```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ The UI is MVC/Thymeleaf, but the domain logic is kept in services so it can be r
 4. `PlayerRepository` saves it.
 5. The controller redirects back to `/players`.
 
-Players start with rating `1200`.
+Players start with a rating of `1200`.
 
 ## Match Flow
 
@@ -58,7 +58,7 @@ Validation rules:
 - selected roster size must match `playerCount`
 
 Manual seeding keeps the submitted player order.
-Random seeding shuffles the selected players before assigning seed numbers.
+Random seeding is intentionally non-deterministic; once saved, seed numbers are the source of truth.
 
 The current feature stores setup data only.
 Tournament match generation and bracket progression are future work.
@@ -67,10 +67,12 @@ Tournament match generation and bracket progression are future work.
 
 Player and match inserts, updates, and deletes are audited through Hibernate event listeners.
 
-The audit listener writes a separate `audit_revision` row with entity name, entity id, operation, actor, timestamp, and a JSONB snapshot.
+The audit listener writes a separate `audit_revision` row with entity name, entity id, operation,
+actor, timestamp, and a JSONB snapshot.
 For matches, player references are stored as ids instead of nested objects to keep snapshots stable.
 
-The actor comes from the configured request header, currently `X-Actor`. If the header is missing, the fallback actor is used.
+The actor comes from the configured request header, currently `X-Actor`.
+If the header is missing, the fallback actor is used.
 
 ## Request Filtering
 

--- a/src/main/java/com/emt/configuration/ExceptionHandlerConfiguration.java
+++ b/src/main/java/com/emt/configuration/ExceptionHandlerConfiguration.java
@@ -2,10 +2,12 @@ package com.emt.configuration;
 
 import com.emt.controller.MatchController;
 import com.emt.controller.PlayerController;
+import com.emt.controller.TournamentController;
 import com.emt.model.exception.IdenticalPlayersException;
 import com.emt.model.exception.MatchNotFoundException;
 import com.emt.model.exception.PlayerAlreadyExistsException;
 import com.emt.model.exception.PlayerNotFoundException;
+import com.emt.model.exception.TournamentCreationException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +23,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Slf4j
-@ControllerAdvice(assignableTypes = {PlayerController.class, MatchController.class})
+@ControllerAdvice(assignableTypes = {PlayerController.class, MatchController.class, TournamentController.class})
 public class ExceptionHandlerConfiguration {
 
   private static final String ERROR_ATTRIBUTE = "error";
@@ -82,6 +84,18 @@ public class ExceptionHandlerConfiguration {
     return redirectTargetFor(request);
   }
 
+  @ExceptionHandler(TournamentCreationException.class)
+  public String handleTournamentCreationException(
+      TournamentCreationException ex,
+      HttpServletRequest request,
+      RedirectAttributes redirectAttributes) {
+    redirectAttributes.addFlashAttribute(
+        ERROR_ATTRIBUTE, "Tournament creation failed: " + ex.getMessage());
+    log.warn("tournament_creation_failed uri={} message={}", request.getRequestURI(), ex.getMessage());
+
+    return redirectTargetFor(request);
+  }
+
   private Map<String, String> extractValidationErrors(Exception ex) {
     Map<String, String> errors = new HashMap<>();
     extractBindingResult(ex)
@@ -117,6 +131,9 @@ public class ExceptionHandlerConfiguration {
     }
     if (uri != null && uri.startsWith("/matches")) {
       return "redirect:/matches";
+    }
+    if (uri != null && uri.startsWith("/tournaments")) {
+      return "redirect:/tournaments";
     }
     return "redirect:/players";
   }

--- a/src/main/java/com/emt/controller/TournamentController.java
+++ b/src/main/java/com/emt/controller/TournamentController.java
@@ -1,0 +1,53 @@
+package com.emt.controller;
+
+import com.emt.model.request.CreateTournamentRequest;
+import com.emt.model.response.PlayerResponse;
+import com.emt.model.response.TournamentResponse;
+import com.emt.model.tournament.BracketType;
+import com.emt.model.tournament.GameFormat;
+import com.emt.model.tournament.SeedingMode;
+import com.emt.service.PlayerService;
+import com.emt.service.TournamentService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/tournaments")
+@RequiredArgsConstructor
+public class TournamentController {
+
+  private final PlayerService playerService;
+  private final TournamentService tournamentService;
+
+  @GetMapping
+  public String getTournaments(Model model) {
+    List<PlayerResponse> players = playerService.getAllPlayers();
+    List<TournamentResponse> tournaments = tournamentService.getAllTournaments();
+
+    model.addAttribute("players", players);
+    model.addAttribute("tournaments", tournaments);
+    model.addAttribute("tournamentRequest", CreateTournamentRequest.builder().build());
+    model.addAttribute("playerCounts", tournamentService.supportedPlayerCounts());
+    model.addAttribute("seedingModes", SeedingMode.values());
+    model.addAttribute("gameFormats", GameFormat.values());
+    model.addAttribute("bracketTypes", BracketType.values());
+    return "tournaments";
+  }
+
+  @PostMapping
+  public String createTournament(
+      @Valid @ModelAttribute("tournamentRequest") CreateTournamentRequest request,
+      RedirectAttributes redirectAttributes) {
+    tournamentService.createTournament(request);
+    redirectAttributes.addFlashAttribute("message", "Tournament created successfully!");
+    return "redirect:/tournaments";
+  }
+}

--- a/src/main/java/com/emt/entity/Tournament.java
+++ b/src/main/java/com/emt/entity/Tournament.java
@@ -1,0 +1,51 @@
+package com.emt.entity;
+
+import com.emt.model.tournament.BracketType;
+import com.emt.model.tournament.GameFormat;
+import com.emt.model.tournament.SeedingMode;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "tournament")
+public class Tournament {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long tournamentId;
+
+  @NotNull private String name;
+  @NotNull private Integer playerCount;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private SeedingMode seedingMode;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private GameFormat gameFormat;
+
+  @NotNull private Integer winningPoints;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private BracketType bracketType;
+
+  @NotNull private Instant createdAt;
+
+  @Builder.Default
+  @OneToMany(mappedBy = "tournament", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderBy("seedNumber ASC")
+  private List<TournamentParticipant> participants = new ArrayList<>();
+}

--- a/src/main/java/com/emt/entity/TournamentParticipant.java
+++ b/src/main/java/com/emt/entity/TournamentParticipant.java
@@ -1,0 +1,31 @@
+package com.emt.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "tournament_participant")
+public class TournamentParticipant {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long tournamentParticipantId;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "tournament_id")
+  private Tournament tournament;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "player_id")
+  private Player player;
+
+  @NotNull private Integer seedNumber;
+}

--- a/src/main/java/com/emt/mapper/TournamentMapper.java
+++ b/src/main/java/com/emt/mapper/TournamentMapper.java
@@ -1,0 +1,69 @@
+package com.emt.mapper;
+
+import com.emt.entity.Player;
+import com.emt.entity.Tournament;
+import com.emt.entity.TournamentParticipant;
+import com.emt.model.request.CreateTournamentRequest;
+import com.emt.model.response.TournamentParticipantResponse;
+import com.emt.model.response.TournamentResponse;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TournamentMapper {
+
+  public Tournament mapToEntity(CreateTournamentRequest request, List<Player> seededPlayers) {
+    Tournament tournament =
+        Tournament.builder()
+            .name(request.name().trim())
+            .playerCount(request.playerCount())
+            .seedingMode(request.seedingMode())
+            .gameFormat(request.gameFormat())
+            .winningPoints(request.winningPoints())
+            .bracketType(request.bracketType())
+            .createdAt(Instant.now())
+            .build();
+
+    for (int i = 0; i < seededPlayers.size(); i++) {
+      tournament
+          .getParticipants()
+          .add(
+              TournamentParticipant.builder()
+                  .tournament(tournament)
+                  .player(seededPlayers.get(i))
+                  .seedNumber(i + 1)
+                  .build());
+    }
+
+    return tournament;
+  }
+
+  public TournamentResponse mapToResponse(Tournament tournament) {
+    return TournamentResponse.builder()
+        .tournamentId(tournament.getTournamentId())
+        .name(tournament.getName())
+        .playerCount(tournament.getPlayerCount())
+        .seedingMode(tournament.getSeedingMode())
+        .gameFormat(tournament.getGameFormat())
+        .winningPoints(tournament.getWinningPoints())
+        .bracketType(tournament.getBracketType())
+        .createdAt(tournament.getCreatedAt())
+        .participants(mapParticipants(tournament))
+        .build();
+  }
+
+  private List<TournamentParticipantResponse> mapParticipants(Tournament tournament) {
+    return tournament.getParticipants().stream()
+        .map(this::mapParticipant)
+        .toList();
+  }
+
+  private TournamentParticipantResponse mapParticipant(TournamentParticipant participant) {
+    return TournamentParticipantResponse.builder()
+        .seedNumber(participant.getSeedNumber())
+        .playerId(participant.getPlayer().getPlayerId())
+        .nickname(participant.getPlayer().getNickname())
+        .build();
+  }
+}

--- a/src/main/java/com/emt/model/exception/TournamentCreationException.java
+++ b/src/main/java/com/emt/model/exception/TournamentCreationException.java
@@ -1,0 +1,9 @@
+package com.emt.model.exception;
+
+public class TournamentCreationException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  public TournamentCreationException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/emt/model/request/CreateTournamentRequest.java
+++ b/src/main/java/com/emt/model/request/CreateTournamentRequest.java
@@ -1,0 +1,23 @@
+package com.emt.model.request;
+
+import com.emt.model.tournament.BracketType;
+import com.emt.model.tournament.GameFormat;
+import com.emt.model.tournament.SeedingMode;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CreateTournamentRequest(
+    @NotBlank(message = "Tournament name should not be blank.")
+        @Size(max = 80, message = "Tournament name must not exceed 80 characters.")
+        String name,
+    @NotNull Integer playerCount,
+    @NotNull SeedingMode seedingMode,
+    @NotNull GameFormat gameFormat,
+    @NotNull @Min(value = 1, message = "Winning points must be positive.") Integer winningPoints,
+    @NotNull BracketType bracketType,
+    List<Long> playerIds) {}

--- a/src/main/java/com/emt/model/response/TournamentParticipantResponse.java
+++ b/src/main/java/com/emt/model/response/TournamentParticipantResponse.java
@@ -1,0 +1,6 @@
+package com.emt.model.response;
+
+import lombok.Builder;
+
+@Builder
+public record TournamentParticipantResponse(Integer seedNumber, Long playerId, String nickname) {}

--- a/src/main/java/com/emt/model/response/TournamentResponse.java
+++ b/src/main/java/com/emt/model/response/TournamentResponse.java
@@ -1,0 +1,20 @@
+package com.emt.model.response;
+
+import com.emt.model.tournament.BracketType;
+import com.emt.model.tournament.GameFormat;
+import com.emt.model.tournament.SeedingMode;
+import java.time.Instant;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record TournamentResponse(
+    Long tournamentId,
+    String name,
+    Integer playerCount,
+    SeedingMode seedingMode,
+    GameFormat gameFormat,
+    Integer winningPoints,
+    BracketType bracketType,
+    Instant createdAt,
+    List<TournamentParticipantResponse> participants) {}

--- a/src/main/java/com/emt/model/tournament/BracketType.java
+++ b/src/main/java/com/emt/model/tournament/BracketType.java
@@ -1,0 +1,16 @@
+package com.emt.model.tournament;
+
+public enum BracketType {
+  SINGLE_ELIMINATION("Single elimination"),
+  ROUND_ROBIN("Round-robin");
+
+  private final String displayName;
+
+  BracketType(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+}

--- a/src/main/java/com/emt/model/tournament/GameFormat.java
+++ b/src/main/java/com/emt/model/tournament/GameFormat.java
@@ -1,0 +1,17 @@
+package com.emt.model.tournament;
+
+public enum GameFormat {
+  BO1("Bo1"),
+  BO3("Bo3"),
+  BO5("Bo5");
+
+  private final String displayName;
+
+  GameFormat(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+}

--- a/src/main/java/com/emt/model/tournament/SeedingMode.java
+++ b/src/main/java/com/emt/model/tournament/SeedingMode.java
@@ -1,0 +1,16 @@
+package com.emt.model.tournament;
+
+public enum SeedingMode {
+  MANUAL("Manual"),
+  RANDOM("Random");
+
+  private final String displayName;
+
+  SeedingMode(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+}

--- a/src/main/java/com/emt/repository/TournamentRepository.java
+++ b/src/main/java/com/emt/repository/TournamentRepository.java
@@ -1,0 +1,21 @@
+package com.emt.repository;
+
+import com.emt.entity.Tournament;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TournamentRepository extends JpaRepository<Tournament, Long> {
+
+  @Query(
+      """
+                  SELECT DISTINCT t
+                  FROM Tournament t
+                  LEFT JOIN FETCH t.participants participant
+                  LEFT JOIN FETCH participant.player
+                  ORDER BY t.createdAt DESC
+                  """)
+  List<Tournament> findAllWithParticipants();
+}

--- a/src/main/java/com/emt/service/TournamentService.java
+++ b/src/main/java/com/emt/service/TournamentService.java
@@ -8,7 +8,6 @@ import com.emt.model.response.TournamentResponse;
 import com.emt.model.tournament.SeedingMode;
 import com.emt.repository.PlayerRepository;
 import com.emt.repository.TournamentRepository;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -39,6 +38,7 @@ public class TournamentService {
 
     List<Player> players = selectedPlayers(request.playerIds());
     if (request.seedingMode() == SeedingMode.RANDOM) {
+      // Random seeding is intentionally non-deterministic; saved seeds are the source of truth.
       Collections.shuffle(players);
     }
 
@@ -81,15 +81,28 @@ public class TournamentService {
   }
 
   private List<Player> selectedPlayers(List<Long> playerIds) {
-    List<Player> players = new ArrayList<>();
-    for (Long playerId : playerIds) {
-      Player player =
-          playerRepository
-              .findById(playerId)
-              .orElseThrow(
-                  () -> new TournamentCreationException("Player not found with id " + playerId));
-      players.add(player);
+    List<Player> foundPlayers = playerRepository.findAllById(playerIds);
+    validateAllPlayersExist(playerIds, foundPlayers);
+
+    return playerIds.stream().map(playerId -> selectedPlayer(foundPlayers, playerId)).toList();
+  }
+
+  private void validateAllPlayersExist(List<Long> playerIds, List<Player> foundPlayers) {
+    List<Long> missingPlayerIds =
+        playerIds.stream().filter(playerId -> playerNotFound(foundPlayers, playerId)).toList();
+    if (!missingPlayerIds.isEmpty()) {
+      throw new TournamentCreationException("Players not found with ids: " + missingPlayerIds);
     }
-    return players;
+  }
+
+  private boolean playerNotFound(List<Player> players, Long playerId) {
+    return players.stream().noneMatch(player -> player.getPlayerId().equals(playerId));
+  }
+
+  private Player selectedPlayer(List<Player> players, Long playerId) {
+    return players.stream()
+        .filter(player -> player.getPlayerId().equals(playerId))
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/src/main/java/com/emt/service/TournamentService.java
+++ b/src/main/java/com/emt/service/TournamentService.java
@@ -1,0 +1,95 @@
+package com.emt.service;
+
+import com.emt.entity.Player;
+import com.emt.mapper.TournamentMapper;
+import com.emt.model.exception.TournamentCreationException;
+import com.emt.model.request.CreateTournamentRequest;
+import com.emt.model.response.TournamentResponse;
+import com.emt.model.tournament.SeedingMode;
+import com.emt.repository.PlayerRepository;
+import com.emt.repository.TournamentRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TournamentService {
+
+  private static final List<Integer> SUPPORTED_PLAYER_COUNTS = List.of(2, 4, 8, 16);
+
+  private final PlayerRepository playerRepository;
+  private final TournamentRepository tournamentRepository;
+  private final TournamentMapper tournamentMapper;
+
+  @Transactional(readOnly = true)
+  public List<TournamentResponse> getAllTournaments() {
+    return tournamentRepository.findAllWithParticipants().stream()
+        .map(tournamentMapper::mapToResponse)
+        .toList();
+  }
+
+  @Transactional
+  public TournamentResponse createTournament(CreateTournamentRequest request) {
+    validateRequest(request);
+
+    List<Player> players = selectedPlayers(request.playerIds());
+    if (request.seedingMode() == SeedingMode.RANDOM) {
+      Collections.shuffle(players);
+    }
+
+    return Optional.of(tournamentMapper.mapToEntity(request, players))
+        .map(tournamentRepository::save)
+        .map(tournamentMapper::mapToResponse)
+        .orElseThrow();
+  }
+
+  public List<Integer> supportedPlayerCounts() {
+    return SUPPORTED_PLAYER_COUNTS;
+  }
+
+  private void validateRequest(CreateTournamentRequest request) {
+    validateSupportedPlayerCount(request.playerCount());
+    validateRoster(request.playerIds(), request.playerCount());
+  }
+
+  private void validateSupportedPlayerCount(Integer playerCount) {
+    if (!SUPPORTED_PLAYER_COUNTS.contains(playerCount)) {
+      throw new TournamentCreationException("Unsupported player count: " + playerCount);
+    }
+  }
+
+  private void validateRoster(List<Long> playerIds, Integer expectedPlayerCount) {
+    if (playerIds == null || playerIds.isEmpty()) {
+      throw new TournamentCreationException("Select players for the tournament.");
+    }
+    if (hasDuplicatePlayerIds(playerIds)) {
+      throw new TournamentCreationException("A player can only be selected once.");
+    }
+    if (playerIds.size() != expectedPlayerCount) {
+      throw new TournamentCreationException(
+          "Expected %s players, got %s.".formatted(expectedPlayerCount, playerIds.size()));
+    }
+  }
+
+  private boolean hasDuplicatePlayerIds(List<Long> playerIds) {
+    return playerIds.stream().distinct().count() != playerIds.size();
+  }
+
+  private List<Player> selectedPlayers(List<Long> playerIds) {
+    List<Player> players = new ArrayList<>();
+    for (Long playerId : playerIds) {
+      Player player =
+          playerRepository
+              .findById(playerId)
+              .orElseThrow(
+                  () -> new TournamentCreationException("Player not found with id " + playerId));
+      players.add(player);
+    }
+    return players;
+  }
+}

--- a/src/main/resources/db/migration/V06__create_tournament_tables.sql
+++ b/src/main/resources/db/migration/V06__create_tournament_tables.sql
@@ -1,0 +1,27 @@
+CREATE TABLE tournament
+(
+    tournament_id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    name          TEXT                     NOT NULL,
+    player_count  INTEGER                  NOT NULL CHECK (player_count IN (2, 4, 8, 16)),
+    seeding_mode  TEXT                     NOT NULL CHECK (seeding_mode IN ('MANUAL', 'RANDOM')),
+    game_format   TEXT                     NOT NULL CHECK (game_format IN ('BO1', 'BO3', 'BO5')),
+    winning_points INTEGER                 NOT NULL CHECK (winning_points > 0),
+    bracket_type  TEXT                     NOT NULL CHECK (bracket_type IN ('SINGLE_ELIMINATION', 'ROUND_ROBIN')),
+    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE TABLE tournament_participant
+(
+    tournament_participant_id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    tournament_id             BIGINT  NOT NULL REFERENCES tournament (tournament_id) ON DELETE CASCADE,
+    player_id                 BIGINT  NOT NULL REFERENCES player (player_id),
+    seed_number               INTEGER NOT NULL CHECK (seed_number > 0),
+    CONSTRAINT uq_tournament_participant_player UNIQUE (tournament_id, player_id),
+    CONSTRAINT uq_tournament_participant_seed UNIQUE (tournament_id, seed_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tournament_created_at ON tournament (created_at);
+CREATE INDEX IF NOT EXISTS idx_tournament_participant_tournament_id
+    ON tournament_participant (tournament_id);
+CREATE INDEX IF NOT EXISTS idx_tournament_participant_player_id
+    ON tournament_participant (player_id);

--- a/src/main/resources/static/styles/styles.css
+++ b/src/main/resources/static/styles/styles.css
@@ -122,6 +122,12 @@ h2 {
     line-height: 1.6;
 }
 
+.muted-copy {
+    margin: 8px 0 0;
+    color: var(--muted);
+    line-height: 1.5;
+}
+
 .panel {
     margin-top: 18px;
     padding: 24px;
@@ -171,6 +177,51 @@ h2 {
     padding: 0;
     margin: 0;
     list-style: none;
+}
+
+.tournament-list {
+    display: grid;
+    gap: 18px;
+}
+
+.tournament-card {
+    padding: 18px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--surface-muted);
+}
+
+.bracket-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.bracket-slot {
+    display: grid;
+    grid-template-columns: 40px minmax(0, 1fr);
+    gap: 12px;
+    align-items: center;
+    min-height: 48px;
+    padding: 0 12px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: #ffffff;
+}
+
+.empty-state {
+    padding: 18px;
+    border: 1px dashed var(--line);
+    border-radius: 8px;
+    color: var(--muted);
+    background: var(--surface-muted);
+}
+
+.empty-state p {
+    margin: 0;
 }
 
 .ranking-row {

--- a/src/main/resources/templates/elo-ranking.html
+++ b/src/main/resources/templates/elo-ranking.html
@@ -12,6 +12,9 @@
             <li class="header-item">
                 <a href="/matches" class="header-link">Match History</a>
             </li>
+            <li class="header-item">
+                <a href="/tournaments" class="header-link">Tournaments</a>
+            </li>
         </ul>
     </nav>
 </header>

--- a/src/main/resources/templates/match-history.html
+++ b/src/main/resources/templates/match-history.html
@@ -12,6 +12,9 @@
             <li class="header-item">
                 <a href="/players" class="header-link">Rankings</a>
             </li>
+            <li class="header-item">
+                <a href="/tournaments" class="header-link">Tournaments</a>
+            </li>
         </ul>
     </nav>
 </header>

--- a/src/main/resources/templates/tournaments.html
+++ b/src/main/resources/templates/tournaments.html
@@ -15,6 +15,9 @@
             <li class="header-item">
                 <a href="/matches" class="header-link">Match History</a>
             </li>
+            <li class="header-item">
+                <a href="/tournaments" class="header-link" aria-current="page">Tournaments</a>
+            </li>
         </ul>
     </nav>
 </header>

--- a/src/main/resources/templates/tournaments.html
+++ b/src/main/resources/templates/tournaments.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <link rel="stylesheet" th:href="@{/styles/styles.css}">
+    <title>Tournaments</title>
+</head>
+<body>
+<header class="page-header">
+    <nav class="header-nav">
+        <a class="brand" href="/players">Elo Match Tracker</a>
+        <ul class="header-list">
+            <li class="header-item">
+                <a href="/players" class="header-link">Rankings</a>
+            </li>
+            <li class="header-item">
+                <a href="/matches" class="header-link">Match History</a>
+            </li>
+        </ul>
+    </nav>
+</header>
+
+<main class="page-shell">
+    <section class="hero">
+        <p class="eyebrow">Tournament desk</p>
+        <h1>Tournaments</h1>
+        <p class="hero-copy">Set up brackets, pick match rules, and seed players manually or at random.</p>
+    </section>
+
+    <div class="alert alert-error" th:if="${error}">
+        <p th:text="${error}">Error occurred</p>
+    </div>
+
+    <div class="alert alert-success" th:if="${message}">
+        <p th:text="${message}">Action completed</p>
+    </div>
+
+    <div class="alert alert-error" th:if="${errors}">
+        <p th:each="entry : ${errors}" th:text="${entry.value}">Validation error</p>
+    </div>
+
+    <section class="form-section panel">
+        <div class="section-title">
+            <h2>Create tournament</h2>
+            <span>Select exactly the configured player count</span>
+        </div>
+        <form th:action="@{/tournaments}" th:object="${tournamentRequest}" method="post">
+            <input type="text" th:field="*{name}" placeholder="Tournament name" required>
+
+            <label for="playerCount">Players</label>
+            <select th:field="*{playerCount}" id="playerCount" required>
+                <option value="" disabled selected>Select size</option>
+                <option th:each="count : ${playerCounts}" th:value="${count}" th:text="${count}"></option>
+            </select>
+
+            <label for="seedingMode">Distribution</label>
+            <select th:field="*{seedingMode}" id="seedingMode" required>
+                <option value="" disabled selected>Select seeding</option>
+                <option th:each="mode : ${seedingModes}"
+                        th:value="${mode}"
+                        th:text="${mode.displayName}"></option>
+            </select>
+
+            <label for="gameFormat">Format</label>
+            <select th:field="*{gameFormat}" id="gameFormat" required>
+                <option value="" disabled selected>Select format</option>
+                <option th:each="format : ${gameFormats}"
+                        th:value="${format}"
+                        th:text="${format.displayName}"></option>
+            </select>
+
+            <label for="winningPoints">Points per set</label>
+            <input type="number" th:field="*{winningPoints}" id="winningPoints" min="1" placeholder="11" required>
+
+            <label for="bracketType">Bracket</label>
+            <select th:field="*{bracketType}" id="bracketType" required>
+                <option value="" disabled selected>Select bracket</option>
+                <option th:each="type : ${bracketTypes}"
+                        th:value="${type}"
+                        th:text="${type.displayName}"></option>
+            </select>
+
+            <label for="playerIds">Roster</label>
+            <select th:field="*{playerIds}" id="playerIds" multiple required>
+                <option th:each="player : ${players}"
+                        th:value="${player.playerId}"
+                        th:text="${player.nickname + ' (' + player.eloRating + ')'}"></option>
+            </select>
+
+            <button type="submit">Create tournament</button>
+        </form>
+    </section>
+
+    <section class="panel">
+        <div class="section-title">
+            <h2>Active tournament setups</h2>
+            <span th:text="${#lists.size(tournaments)} + ' tournaments'">0 tournaments</span>
+        </div>
+
+        <div class="empty-state" th:if="${#lists.isEmpty(tournaments)}">
+            <p>No tournaments yet. Create one after registering enough players.</p>
+        </div>
+
+        <div class="tournament-list" th:if="${!#lists.isEmpty(tournaments)}">
+            <article class="tournament-card" th:each="tournament : ${tournaments}">
+                <div class="section-title">
+                    <div>
+                        <h2 th:text="${tournament.name}">Tournament name</h2>
+                        <p class="muted-copy"
+                           th:text="${tournament.playerCount + ' players · ' + tournament.gameFormat.displayName + ' · ' + tournament.winningPoints + ' points · ' + tournament.bracketType.displayName}">
+                            Rules
+                        </p>
+                    </div>
+                    <span th:text="${tournament.seedingMode.displayName} + ' seeding'">Manual seeding</span>
+                </div>
+
+                <ol class="bracket-grid">
+                    <li th:each="participant : ${tournament.participants}" class="bracket-slot">
+                        <span class="rank" th:text="${participant.seedNumber}">1</span>
+                        <span class="nickname" th:text="${participant.nickname}">Player</span>
+                    </li>
+                </ol>
+            </article>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/src/test/integration/java/com/emt/controller/TournamentControllerIT.java
+++ b/src/test/integration/java/com/emt/controller/TournamentControllerIT.java
@@ -1,0 +1,141 @@
+package com.emt.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import com.emt.ITBase;
+import com.emt.model.request.CreatePlayerRequest;
+import com.emt.model.request.CreateTournamentRequest;
+import com.emt.model.response.TournamentResponse;
+import com.emt.model.tournament.BracketType;
+import com.emt.model.tournament.GameFormat;
+import com.emt.model.tournament.SeedingMode;
+import com.emt.repository.TournamentRepository;
+import com.emt.service.PlayerService;
+import com.emt.service.TournamentService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@RequiredArgsConstructor
+class TournamentControllerIT extends ITBase {
+
+  private static final String TOURNAMENTS_PATH = "/tournaments";
+  private static final String TOURNAMENTS_VIEW = "tournaments";
+
+  private final MockMvc mockMvc;
+  private final PlayerService playerService;
+  private final TournamentRepository tournamentRepository;
+  private final TournamentService tournamentService;
+
+  @Test
+  void getTournaments_ShouldRenderTournamentSetupPage() throws Exception {
+    mockMvc
+        .perform(get(TOURNAMENTS_PATH))
+        .andExpect(status().isOk())
+        .andExpect(view().name(TOURNAMENTS_VIEW))
+        .andExpect(model().attributeExists("players"))
+        .andExpect(model().attributeExists("tournaments"))
+        .andExpect(model().attributeExists("tournamentRequest"))
+        .andExpect(model().attributeExists("playerCounts"))
+        .andExpect(model().attributeExists("seedingModes"))
+        .andExpect(model().attributeExists("gameFormats"))
+        .andExpect(model().attributeExists("bracketTypes"));
+  }
+
+  @Test
+  void createTournament_withValidRequest_ShouldCreateTournament() throws Exception {
+    Long firstPlayerId = createPlayer("BracketOne");
+    Long secondPlayerId = createPlayer("BracketTwo");
+
+    mockMvc
+        .perform(
+            post(TOURNAMENTS_PATH)
+                .param("name", "Friday Finals")
+                .param("playerCount", "2")
+                .param("seedingMode", "MANUAL")
+                .param("gameFormat", "BO3")
+                .param("winningPoints", "11")
+                .param("bracketType", "SINGLE_ELIMINATION")
+                .param("playerIds", String.valueOf(firstPlayerId), String.valueOf(secondPlayerId)))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(TOURNAMENTS_PATH))
+        .andExpect(flash().attribute("message", "Tournament created successfully!"));
+
+    List<TournamentResponse> tournaments = tournamentService.getAllTournaments();
+
+    assertThat(tournaments).hasSize(1);
+    assertThat(tournaments.get(0).name()).isEqualTo("Friday Finals");
+    assertThat(tournaments.get(0).participants())
+        .extracting(participant -> participant.nickname())
+        .containsExactly("BracketOne", "BracketTwo");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void getTournaments_withExistingTournament_ShouldExposeSeededGrid() throws Exception {
+    Long firstPlayerId = createPlayer("GridOne");
+    Long secondPlayerId = createPlayer("GridTwo");
+    tournamentService.createTournament(
+        CreateTournamentRequest.builder()
+            .name("Grid Cup")
+            .playerCount(2)
+            .seedingMode(SeedingMode.MANUAL)
+            .gameFormat(GameFormat.BO1)
+            .winningPoints(21)
+            .bracketType(BracketType.ROUND_ROBIN)
+            .playerIds(List.of(firstPlayerId, secondPlayerId))
+            .build());
+
+    MvcResult result =
+        mockMvc
+            .perform(get(TOURNAMENTS_PATH))
+            .andExpect(status().isOk())
+            .andExpect(view().name(TOURNAMENTS_VIEW))
+            .andReturn();
+
+    List<TournamentResponse> tournaments =
+        (List<TournamentResponse>) result.getModelAndView().getModel().get("tournaments");
+
+    assertThat(tournaments).hasSize(1);
+    assertThat(tournaments.get(0).participants())
+        .extracting(participant -> participant.seedNumber())
+        .containsExactly(1, 2);
+  }
+
+  @Test
+  void createTournament_withRosterMismatch_ShouldRedirectWithError() throws Exception {
+    Long firstPlayerId = createPlayer("MismatchOne");
+    createPlayer("MismatchTwo");
+
+    mockMvc
+        .perform(
+            post(TOURNAMENTS_PATH)
+                .param("name", "Mismatch Cup")
+                .param("playerCount", "2")
+                .param("seedingMode", "MANUAL")
+                .param("gameFormat", "BO1")
+                .param("winningPoints", "11")
+                .param("bracketType", "SINGLE_ELIMINATION")
+                .param("playerIds", String.valueOf(firstPlayerId)))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(TOURNAMENTS_PATH))
+        .andExpect(flash().attributeExists("error"));
+
+    assertThat(tournamentRepository.findAll()).isEmpty();
+  }
+
+  private Long createPlayer(String nickname) {
+    return playerService
+        .createPlayer(CreatePlayerRequest.builder().nickname(nickname).build())
+        .playerId();
+  }
+}

--- a/src/test/unit/java/com/emt/service/TournamentServiceTest.java
+++ b/src/test/unit/java/com/emt/service/TournamentServiceTest.java
@@ -19,7 +19,6 @@ import com.emt.repository.TournamentRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -31,6 +30,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class TournamentServiceTest {
 
+  private static final String FIRST_PLAYER = "FirstPlayer";
+  private static final String SECOND_PLAYER = "SecondPlayer";
+
   @Mock private PlayerRepository playerRepository;
   @Mock private TournamentRepository tournamentRepository;
   @Spy private TournamentMapper tournamentMapper;
@@ -38,12 +40,12 @@ class TournamentServiceTest {
 
   @Test
   void createTournament_withManualSeeding_ShouldPersistSeededRoster() {
-    Player firstPlayer = player(1L, "FirstPlayer");
-    Player secondPlayer = player(2L, "SecondPlayer");
+    Player firstPlayer = player(1L, FIRST_PLAYER);
+    Player secondPlayer = player(2L, SECOND_PLAYER);
     CreateTournamentRequest request = tournamentRequest(List.of(1L, 2L));
 
-    given(playerRepository.findById(1L)).willReturn(Optional.of(firstPlayer));
-    given(playerRepository.findById(2L)).willReturn(Optional.of(secondPlayer));
+    given(playerRepository.findAllById(List.of(1L, 2L)))
+        .willReturn(List.of(secondPlayer, firstPlayer));
     given(tournamentRepository.save(org.mockito.ArgumentMatchers.any(Tournament.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
 
@@ -57,7 +59,7 @@ class TournamentServiceTest {
     assertThat(savedTournament.getParticipants()).hasSize(2);
     assertThat(savedTournament.getParticipants())
         .extracting(participant -> participant.getPlayer().getNickname())
-        .containsExactly("FirstPlayer", "SecondPlayer");
+        .containsExactly(FIRST_PLAYER, SECOND_PLAYER);
     assertThat(response.participants())
         .extracting(participant -> participant.seedNumber())
         .containsExactly(1, 2);
@@ -89,6 +91,16 @@ class TournamentServiceTest {
   }
 
   @Test
+  void createTournament_withUnknownPlayer_ShouldThrowException() {
+    given(playerRepository.findAllById(List.of(1L, 2L)))
+        .willReturn(List.of(player(1L, FIRST_PLAYER)));
+
+    assertThatThrownBy(() -> tournamentService.createTournament(tournamentRequest(List.of(1L, 2L))))
+        .isInstanceOf(TournamentCreationException.class)
+        .hasMessageContaining("Players not found with ids: [2]");
+  }
+
+  @Test
   void createTournament_withRosterSizeMismatch_ShouldThrowException() {
     assertThatThrownBy(
             () ->
@@ -108,7 +120,7 @@ class TournamentServiceTest {
 
   @Test
   void getAllTournaments_ShouldReturnTournamentResponses() {
-    Player firstPlayer = player(1L, "FirstPlayer");
+    Player firstPlayer = player(1L, FIRST_PLAYER);
     Tournament tournament =
         Tournament.builder()
             .tournamentId(10L)

--- a/src/test/unit/java/com/emt/service/TournamentServiceTest.java
+++ b/src/test/unit/java/com/emt/service/TournamentServiceTest.java
@@ -1,0 +1,156 @@
+package com.emt.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.emt.entity.Player;
+import com.emt.entity.Tournament;
+import com.emt.mapper.TournamentMapper;
+import com.emt.model.exception.TournamentCreationException;
+import com.emt.model.request.CreateTournamentRequest;
+import com.emt.model.response.TournamentResponse;
+import com.emt.model.tournament.BracketType;
+import com.emt.model.tournament.GameFormat;
+import com.emt.model.tournament.SeedingMode;
+import com.emt.repository.PlayerRepository;
+import com.emt.repository.TournamentRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TournamentServiceTest {
+
+  @Mock private PlayerRepository playerRepository;
+  @Mock private TournamentRepository tournamentRepository;
+  @Spy private TournamentMapper tournamentMapper;
+  @InjectMocks private TournamentService tournamentService;
+
+  @Test
+  void createTournament_withManualSeeding_ShouldPersistSeededRoster() {
+    Player firstPlayer = player(1L, "FirstPlayer");
+    Player secondPlayer = player(2L, "SecondPlayer");
+    CreateTournamentRequest request = tournamentRequest(List.of(1L, 2L));
+
+    given(playerRepository.findById(1L)).willReturn(Optional.of(firstPlayer));
+    given(playerRepository.findById(2L)).willReturn(Optional.of(secondPlayer));
+    given(tournamentRepository.save(org.mockito.ArgumentMatchers.any(Tournament.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    TournamentResponse response = tournamentService.createTournament(request);
+
+    ArgumentCaptor<Tournament> tournamentCaptor = ArgumentCaptor.forClass(Tournament.class);
+    verify(tournamentRepository).save(tournamentCaptor.capture());
+    Tournament savedTournament = tournamentCaptor.getValue();
+
+    assertThat(savedTournament.getName()).isEqualTo("Summer Finals");
+    assertThat(savedTournament.getParticipants()).hasSize(2);
+    assertThat(savedTournament.getParticipants())
+        .extracting(participant -> participant.getPlayer().getNickname())
+        .containsExactly("FirstPlayer", "SecondPlayer");
+    assertThat(response.participants())
+        .extracting(participant -> participant.seedNumber())
+        .containsExactly(1, 2);
+  }
+
+  @Test
+  void createTournament_withUnsupportedPlayerCount_ShouldThrowException() {
+    assertThatThrownBy(
+            () ->
+                tournamentService.createTournament(
+                    CreateTournamentRequest.builder()
+                        .name("Bad size")
+                        .playerCount(3)
+                        .seedingMode(SeedingMode.MANUAL)
+                        .gameFormat(GameFormat.BO1)
+                        .winningPoints(11)
+                        .bracketType(BracketType.SINGLE_ELIMINATION)
+                        .playerIds(List.of(1L, 2L, 3L))
+                        .build()))
+        .isInstanceOf(TournamentCreationException.class)
+        .hasMessageContaining("Unsupported player count");
+  }
+
+  @Test
+  void createTournament_withDuplicatePlayers_ShouldThrowException() {
+    assertThatThrownBy(() -> tournamentService.createTournament(tournamentRequest(List.of(1L, 1L))))
+        .isInstanceOf(TournamentCreationException.class)
+        .hasMessageContaining("only be selected once");
+  }
+
+  @Test
+  void createTournament_withRosterSizeMismatch_ShouldThrowException() {
+    assertThatThrownBy(
+            () ->
+                tournamentService.createTournament(
+                    CreateTournamentRequest.builder()
+                        .name("Bad roster")
+                        .playerCount(4)
+                        .seedingMode(SeedingMode.MANUAL)
+                        .gameFormat(GameFormat.BO3)
+                        .winningPoints(11)
+                        .bracketType(BracketType.ROUND_ROBIN)
+                        .playerIds(List.of(1L, 2L))
+                        .build()))
+        .isInstanceOf(TournamentCreationException.class)
+        .hasMessageContaining("Expected 4 players");
+  }
+
+  @Test
+  void getAllTournaments_ShouldReturnTournamentResponses() {
+    Player firstPlayer = player(1L, "FirstPlayer");
+    Tournament tournament =
+        Tournament.builder()
+            .tournamentId(10L)
+            .name("Stored Tournament")
+            .playerCount(2)
+            .seedingMode(SeedingMode.MANUAL)
+            .gameFormat(GameFormat.BO1)
+            .winningPoints(21)
+            .bracketType(BracketType.ROUND_ROBIN)
+            .createdAt(Instant.now())
+            .build();
+    tournament
+        .getParticipants()
+        .add(
+            com.emt.entity.TournamentParticipant.builder()
+                .tournament(tournament)
+                .player(firstPlayer)
+                .seedNumber(1)
+                .build());
+
+    given(tournamentRepository.findAllWithParticipants()).willReturn(List.of(tournament));
+
+    List<TournamentResponse> tournaments = tournamentService.getAllTournaments();
+
+    assertThat(tournaments).hasSize(1);
+    assertThat(tournaments.get(0).name()).isEqualTo("Stored Tournament");
+    assertThat(tournaments.get(0).participants()).hasSize(1);
+  }
+
+  private CreateTournamentRequest tournamentRequest(List<Long> playerIds) {
+    return CreateTournamentRequest.builder()
+        .name(" Summer Finals ")
+        .playerCount(2)
+        .seedingMode(SeedingMode.MANUAL)
+        .gameFormat(GameFormat.BO3)
+        .winningPoints(11)
+        .bracketType(BracketType.SINGLE_ELIMINATION)
+        .playerIds(playerIds)
+        .build();
+  }
+
+  private Player player(Long playerId, String nickname) {
+    return new Player(playerId, nickname, new BigDecimal("1200"), Instant.now());
+  }
+}


### PR DESCRIPTION
## Summary

Added tournament management support with a dedicated UI page for creating and viewing tournament setups.

## What Changed

- Added tournament and tournament participant entities.
- Added Flyway migration for tournament tables and constraints.
- Added tournament setup flow with:
  - player count: 2/4/8/16
  - manual or random seeding
  - game format: Bo1/Bo3/Bo5
  - custom winning points
  - bracket type: single elimination or round-robin
- Added `/tournaments` MVC page.
- Added tournament service validation and mapping layer.
- Added unit and integration tests for tournament creation flows.
- Updated project documentation with tournament behavior and architecture notes.

## Notes

This feature stores tournament setup and seeded participants. Match generation, result reporting, and bracket progression are planned as future work.

## Summary by Sourcery

Add tournament setup and viewing to the MVC app, including persistence, validation, and UI, and update documentation to describe tournaments and revised behavior.

New Features:
- Introduce tournament and tournament participant domain models with enums for seeding mode, game format, and bracket type, persisted via new Flyway migrations.
- Expose a `/tournaments` MVC page that lets users configure tournaments (size, seeding, format, scoring, bracket) and view seeded participant grids.
- Add a tournament service, mapper, repository, and request/response models to handle tournament creation and retrieval with manual or random seeding.

Enhancements:
- Extend global MVC exception handling to surface tournament creation errors as flash messages and redirect back to the tournaments page.
- Refine API, architecture, and README documentation to cover tournaments, clarify MVC behavior, local URLs, and testing/quality expectations.
- Enhance UI styling with components for muted copy, tournament cards, bracket grids, and empty-state messaging.

Documentation:
- Update API and architecture docs to describe tournaments, Elo rules, error behavior, and local endpoint usage, and refresh README to include the tournament feature and revised roadmap.

Tests:
- Add unit tests for the tournament service validation and mapping behavior, and integration tests for the tournaments controller and seeded bracket exposure.