### PR TITLE
feat: full tournament engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The service layer is separated from controllers, so adding a REST API later shou
 - Report match results and update both players in one transaction.
 - Cancel matches and repair later rating history.
 - Filter match history by one player or by a pair of players.
-- Create tournament setups with roster size, seeding mode, game format, scoring, and bracket type.
+- Create tournaments, generate brackets, record results, and finish winners.
 - Store audit revisions for player and match changes.
 - Add correlation ids to requests for easier log tracing.
 - Expose basic business metrics through Actuator.
@@ -73,5 +73,4 @@ http://localhost:9090/actuator/metrics
 - Add a separate JSON REST API for external clients.
 - Add player search and pagination.
 - Add match notes and optional game modes.
-- Add tournament result tracking and bracket progression.
 - Add authentication for admin actions.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The service layer is separated from controllers, so adding a REST API later shou
 - Report match results and update both players in one transaction.
 - Cancel matches and repair later rating history.
 - Filter match history by one player or by a pair of players.
-- Create tournaments, generate brackets, record results, and finish winners.
+- Create tournaments, generate brackets, record results, and determine winners.
 - Store audit revisions for player and match changes.
 - Add correlation ids to requests for easier log tracing.
 - Expose basic business metrics through Actuator.

--- a/docs/API.md
+++ b/docs/API.md
@@ -157,7 +157,8 @@ The page contains:
 
 - tournament creation form
 - player list for seeding
-- existing tournament setups with seed order
+- saved tournaments with seed order
+- generated tournament matches and result buttons
 
 ### `POST /tournaments`
 
@@ -198,8 +199,36 @@ curl -i -X POST \
 Manual seeding keeps the submitted player order.
 Random seeding is intentionally non-deterministic; once saved, seed numbers are the source of truth.
 
-Current limitation: tournaments store setup and participants only.
-Match generation, results, and bracket progression are planned separately.
+### `POST /tournaments/{tournamentId}/start`
+
+Starts a draft tournament and generates its first playable matches.
+
+Single elimination pairs top seeds against bottom seeds in the first round.
+Round-robin uses a simple rotating schedule so every player meets every other player once.
+
+Success:
+
+- redirects to `/tournaments`
+- shows `Tournament started successfully!`
+
+### `POST /tournaments/matches/{tournamentMatchId}/report`
+
+Records a tournament match winner.
+
+Form fields:
+
+| Name | Required | Notes |
+| --- | --- | --- |
+| `winnerId` | Yes | Must be one of the two players in the tournament match. |
+
+The service also creates a normal match record, so Elo ratings and match history stay consistent.
+When a single-elimination round is complete, winners move into the next round.
+When the final or round-robin schedule is complete, the tournament is marked as completed with a winner.
+
+Success:
+
+- redirects to `/tournaments`
+- shows `Tournament match recorded successfully!`
 
 ## Elo Rules
 
@@ -258,7 +287,7 @@ Redirect targets:
 | --- | --- |
 | Players | `/players` |
 | Match reporting | `/players` |
+| Tournament engine | `/tournaments` |
 | Match history or cancellation | `/matches` |
-| Tournaments | `/tournaments` |
 
 Clients should not expect JSON error bodies from these MVC endpoints.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,13 +42,13 @@ The service reverts the cancelled match delta, recalculates later matches for th
 updates stored deltas, and removes the cancelled match.
 This is more work than a delete, but it keeps Elo ratings correct because Elo depends on match order.
 
-## Tournament Setup
+## Tournament Flow
 
 Tournaments follow the same structure as players and matches.
 
-`TournamentController` renders the page and submits create requests.
-`TournamentService` validates the roster and applies seeding rules.
-`TournamentMapper` builds the `Tournament` entity and maps saved tournaments back to response models.
+`TournamentController` renders the page, submits create requests, starts brackets, and records tournament match winners.
+`TournamentService` owns roster validation, seeding, bracket generation, progression, and completion rules.
+`TournamentMapper` builds tournament setup entities and maps saved tournaments back to response models.
 
 Validation rules:
 
@@ -60,8 +60,14 @@ Validation rules:
 Manual seeding keeps the submitted player order.
 Random seeding is intentionally non-deterministic; once saved, seed numbers are the source of truth.
 
-The current feature stores setup data only.
-Tournament match generation and bracket progression are future work.
+Lifecycle rules:
+
+- tournaments start as `DRAFT`
+- starting a tournament creates pending `TournamentMatch` rows
+- reporting a tournament match also creates a normal Elo match
+- single-elimination winners move into the next round after the whole round is complete
+- round-robin winners are ranked by wins, with seed order as the tie-breaker
+- completed tournaments store the final winner and completion time
 
 ## Auditing
 
@@ -99,6 +105,7 @@ Important database choices:
 - match history fields are indexed for filtering and recalculation
 - audit revisions are indexed for lookup by entity, operation, and creation time
 - tournament participants have unique constraints for player membership and seed number per tournament
+- tournament matches have unique round and match slots per tournament
 
 ## Profiles
 

--- a/src/main/java/com/emt/configuration/TimeConfiguration.java
+++ b/src/main/java/com/emt/configuration/TimeConfiguration.java
@@ -1,0 +1,14 @@
+package com.emt.configuration;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfiguration {
+
+  @Bean
+  public Clock clock() {
+    return Clock.systemUTC();
+  }
+}

--- a/src/main/java/com/emt/controller/TournamentController.java
+++ b/src/main/java/com/emt/controller/TournamentController.java
@@ -15,7 +15,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
@@ -48,6 +50,24 @@ public class TournamentController {
       RedirectAttributes redirectAttributes) {
     tournamentService.createTournament(request);
     redirectAttributes.addFlashAttribute("message", "Tournament created successfully!");
+    return "redirect:/tournaments";
+  }
+
+  @PostMapping("/{tournamentId}/start")
+  public String startTournament(
+      @PathVariable Long tournamentId, RedirectAttributes redirectAttributes) {
+    tournamentService.startTournament(tournamentId);
+    redirectAttributes.addFlashAttribute("message", "Tournament started successfully!");
+    return "redirect:/tournaments";
+  }
+
+  @PostMapping("/matches/{tournamentMatchId}/report")
+  public String reportTournamentMatch(
+      @PathVariable Long tournamentMatchId,
+      @RequestParam Long winnerId,
+      RedirectAttributes redirectAttributes) {
+    tournamentService.reportTournamentMatchResult(tournamentMatchId, winnerId);
+    redirectAttributes.addFlashAttribute("message", "Tournament match recorded successfully!");
     return "redirect:/tournaments";
   }
 }

--- a/src/main/java/com/emt/entity/Tournament.java
+++ b/src/main/java/com/emt/entity/Tournament.java
@@ -3,6 +3,7 @@ package com.emt.entity;
 import com.emt.model.tournament.BracketType;
 import com.emt.model.tournament.GameFormat;
 import com.emt.model.tournament.SeedingMode;
+import com.emt.model.tournament.TournamentStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
@@ -42,10 +43,26 @@ public class Tournament {
   @Enumerated(EnumType.STRING)
   private BracketType bracketType;
 
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  private TournamentStatus status = TournamentStatus.DRAFT;
+
+  @ManyToOne
+  @JoinColumn(name = "winner_id")
+  private Player winner;
+
   @NotNull private Instant createdAt;
+  private Instant startedAt;
+  private Instant completedAt;
 
   @Builder.Default
   @OneToMany(mappedBy = "tournament", cascade = CascadeType.ALL, orphanRemoval = true)
   @OrderBy("seedNumber ASC")
   private List<TournamentParticipant> participants = new ArrayList<>();
+
+  @Builder.Default
+  @OneToMany(mappedBy = "tournament", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderBy("roundNumber ASC, matchNumber ASC")
+  private List<TournamentMatch> matches = new ArrayList<>();
 }

--- a/src/main/java/com/emt/entity/TournamentMatch.java
+++ b/src/main/java/com/emt/entity/TournamentMatch.java
@@ -1,0 +1,51 @@
+package com.emt.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.emt.model.tournament.TournamentMatchStatus;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "tournament_match")
+public class TournamentMatch {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long tournamentMatchId;
+
+  @ManyToOne(optional = false, fetch = LAZY)
+  @JoinColumn(name = "tournament_id")
+  private Tournament tournament;
+
+  @NotNull private Integer roundNumber;
+  @NotNull private Integer matchNumber;
+
+  @ManyToOne(optional = false, fetch = LAZY)
+  @JoinColumn(name = "first_player_id")
+  private Player firstPlayer;
+
+  @ManyToOne(optional = false, fetch = LAZY)
+  @JoinColumn(name = "second_player_id")
+  private Player secondPlayer;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "winner_id")
+  private Player winner;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private TournamentMatchStatus status;
+
+  @NotNull private Instant createdAt;
+  private Instant completedAt;
+}

--- a/src/main/java/com/emt/mapper/TournamentMapper.java
+++ b/src/main/java/com/emt/mapper/TournamentMapper.java
@@ -2,8 +2,10 @@ package com.emt.mapper;
 
 import com.emt.entity.Player;
 import com.emt.entity.Tournament;
+import com.emt.entity.TournamentMatch;
 import com.emt.entity.TournamentParticipant;
 import com.emt.model.request.CreateTournamentRequest;
+import com.emt.model.response.TournamentMatchResponse;
 import com.emt.model.response.TournamentParticipantResponse;
 import com.emt.model.response.TournamentResponse;
 import java.time.Instant;
@@ -48,8 +50,14 @@ public class TournamentMapper {
         .gameFormat(tournament.getGameFormat())
         .winningPoints(tournament.getWinningPoints())
         .bracketType(tournament.getBracketType())
+        .status(tournament.getStatus())
+        .winnerId(playerId(tournament.getWinner()))
+        .winnerNickname(nickname(tournament.getWinner()))
         .createdAt(tournament.getCreatedAt())
+        .startedAt(tournament.getStartedAt())
+        .completedAt(tournament.getCompletedAt())
         .participants(mapParticipants(tournament))
+        .matches(mapMatches(tournament))
         .build();
   }
 
@@ -65,5 +73,33 @@ public class TournamentMapper {
         .playerId(participant.getPlayer().getPlayerId())
         .nickname(participant.getPlayer().getNickname())
         .build();
+  }
+
+  private List<TournamentMatchResponse> mapMatches(Tournament tournament) {
+    return tournament.getMatches().stream().map(this::mapMatch).toList();
+  }
+
+  private TournamentMatchResponse mapMatch(TournamentMatch match) {
+    return TournamentMatchResponse.builder()
+        .tournamentMatchId(match.getTournamentMatchId())
+        .roundNumber(match.getRoundNumber())
+        .matchNumber(match.getMatchNumber())
+        .status(match.getStatus())
+        .firstPlayerId(match.getFirstPlayer().getPlayerId())
+        .firstPlayerNickname(match.getFirstPlayer().getNickname())
+        .secondPlayerId(match.getSecondPlayer().getPlayerId())
+        .secondPlayerNickname(match.getSecondPlayer().getNickname())
+        .winnerId(playerId(match.getWinner()))
+        .winnerNickname(nickname(match.getWinner()))
+        .completedAt(match.getCompletedAt())
+        .build();
+  }
+
+  private Long playerId(Player player) {
+    return player == null ? null : player.getPlayerId();
+  }
+
+  private String nickname(Player player) {
+    return player == null ? null : player.getNickname();
   }
 }

--- a/src/main/java/com/emt/model/response/TournamentMatchResponse.java
+++ b/src/main/java/com/emt/model/response/TournamentMatchResponse.java
@@ -1,0 +1,19 @@
+package com.emt.model.response;
+
+import com.emt.model.tournament.TournamentMatchStatus;
+import java.time.Instant;
+import lombok.Builder;
+
+@Builder
+public record TournamentMatchResponse(
+    Long tournamentMatchId,
+    Integer roundNumber,
+    Integer matchNumber,
+    TournamentMatchStatus status,
+    Long firstPlayerId,
+    String firstPlayerNickname,
+    Long secondPlayerId,
+    String secondPlayerNickname,
+    Long winnerId,
+    String winnerNickname,
+    Instant completedAt) {}

--- a/src/main/java/com/emt/model/response/TournamentResponse.java
+++ b/src/main/java/com/emt/model/response/TournamentResponse.java
@@ -3,6 +3,7 @@ package com.emt.model.response;
 import com.emt.model.tournament.BracketType;
 import com.emt.model.tournament.GameFormat;
 import com.emt.model.tournament.SeedingMode;
+import com.emt.model.tournament.TournamentStatus;
 import java.time.Instant;
 import java.util.List;
 import lombok.Builder;
@@ -16,5 +17,11 @@ public record TournamentResponse(
     GameFormat gameFormat,
     Integer winningPoints,
     BracketType bracketType,
+    TournamentStatus status,
+    Long winnerId,
+    String winnerNickname,
     Instant createdAt,
-    List<TournamentParticipantResponse> participants) {}
+    Instant startedAt,
+    Instant completedAt,
+    List<TournamentParticipantResponse> participants,
+    List<TournamentMatchResponse> matches) {}

--- a/src/main/java/com/emt/model/tournament/TournamentMatchStatus.java
+++ b/src/main/java/com/emt/model/tournament/TournamentMatchStatus.java
@@ -1,0 +1,16 @@
+package com.emt.model.tournament;
+
+public enum TournamentMatchStatus {
+  PENDING("Pending"),
+  COMPLETED("Completed");
+
+  private final String displayName;
+
+  TournamentMatchStatus(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+}

--- a/src/main/java/com/emt/model/tournament/TournamentStatus.java
+++ b/src/main/java/com/emt/model/tournament/TournamentStatus.java
@@ -1,0 +1,18 @@
+package com.emt.model.tournament;
+
+public enum TournamentStatus {
+  DRAFT("Draft"),
+  ACTIVE("Active"),
+  COMPLETED("Completed"),
+  CANCELLED("Cancelled");
+
+  private final String displayName;
+
+  TournamentStatus(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+}

--- a/src/main/java/com/emt/repository/TournamentMatchRepository.java
+++ b/src/main/java/com/emt/repository/TournamentMatchRepository.java
@@ -1,0 +1,14 @@
+package com.emt.repository;
+
+import com.emt.entity.TournamentMatch;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TournamentMatchRepository extends JpaRepository<TournamentMatch, Long> {
+
+  @EntityGraph(attributePaths = {"tournament", "firstPlayer", "secondPlayer", "winner"})
+  Optional<TournamentMatch> findWithPlayersByTournamentMatchId(Long tournamentMatchId);
+}

--- a/src/main/java/com/emt/service/TournamentService.java
+++ b/src/main/java/com/emt/service/TournamentService.java
@@ -3,7 +3,6 @@ package com.emt.service;
 import com.emt.entity.Player;
 import com.emt.entity.Tournament;
 import com.emt.entity.TournamentMatch;
-import com.emt.entity.TournamentParticipant;
 import com.emt.mapper.TournamentMapper;
 import com.emt.metrics.BusinessMetrics;
 import com.emt.model.exception.TournamentCreationException;
@@ -17,14 +16,12 @@ import com.emt.model.tournament.TournamentStatus;
 import com.emt.repository.PlayerRepository;
 import com.emt.repository.TournamentMatchRepository;
 import com.emt.repository.TournamentRepository;
+import com.emt.service.tournament.TournamentBracketStrategy;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,8 +32,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class TournamentService {
 
   private static final List<Integer> SUPPORTED_PLAYER_COUNTS = List.of(2, 4, 8, 16);
-  private static final int FIRST_ROUND = 1;
-  private static final int FINALIST_COUNT = 1;
 
   private final PlayerRepository playerRepository;
   private final TournamentRepository tournamentRepository;
@@ -44,6 +39,8 @@ public class TournamentService {
   private final TournamentMapper tournamentMapper;
   private final MatchService matchService;
   private final BusinessMetrics businessMetrics;
+  private final Clock clock;
+  private final List<TournamentBracketStrategy> bracketStrategies;
 
   @Transactional(readOnly = true)
   public List<TournamentResponse> getAllTournaments() {
@@ -76,14 +73,10 @@ public class TournamentService {
     Tournament tournament = getTournament(tournamentId);
     validateTournamentCanStart(tournament);
 
-    if (tournament.getBracketType() == BracketType.SINGLE_ELIMINATION) {
-      createSingleEliminationFirstRound(tournament);
-    } else {
-      createRoundRobinMatches(tournament);
-    }
-
+    bracketStrategy(tournament.getBracketType()).createInitialMatches(tournament);
     tournament.setStatus(TournamentStatus.ACTIVE);
-    tournament.setStartedAt(Instant.now(Clock.systemUTC()));
+    tournament.setStartedAt(Instant.now(clock));
+
     return tournamentMapper.mapToResponse(tournamentRepository.save(tournament));
   }
 
@@ -102,7 +95,8 @@ public class TournamentService {
             .build());
 
     completeTournamentMatch(tournamentMatch, winner);
-    progressTournament(tournament, tournamentMatch.getRoundNumber());
+    bracketStrategy(tournament.getBracketType())
+        .progressAfterResult(tournament, tournamentMatch.getRoundNumber());
 
     return tournamentMapper.mapToResponse(tournamentRepository.save(tournament));
   }
@@ -124,6 +118,14 @@ public class TournamentService {
             () -> new TournamentCreationException("Tournament match not found: " + tournamentMatchId));
   }
 
+  private TournamentBracketStrategy bracketStrategy(BracketType bracketType) {
+    return bracketStrategies.stream()
+        .filter(strategy -> strategy.bracketType() == bracketType)
+        .findFirst()
+        .orElseThrow(
+            () -> new TournamentCreationException("Unsupported bracket type: " + bracketType));
+  }
+
   private void validateTournamentCanStart(Tournament tournament) {
     if (tournament.getStatus() != TournamentStatus.DRAFT) {
       throw new TournamentCreationException("Only draft tournaments can be started.");
@@ -134,67 +136,6 @@ public class TournamentService {
     if (tournament.getParticipants().size() != tournament.getPlayerCount()) {
       throw new TournamentCreationException("Tournament roster is incomplete.");
     }
-  }
-
-  private void createSingleEliminationFirstRound(Tournament tournament) {
-    List<Player> seededPlayers = seededPlayers(tournament);
-    for (int i = 0; i < seededPlayers.size() / 2; i++) {
-      addTournamentMatch(
-          tournament,
-          FIRST_ROUND,
-          i + 1,
-          seededPlayers.get(i),
-          seededPlayers.get(seededPlayers.size() - 1 - i));
-    }
-  }
-
-  private void createRoundRobinMatches(Tournament tournament) {
-    List<Player> rotation = new ArrayList<>(seededPlayers(tournament));
-    int playerCount = rotation.size();
-
-    for (int roundNumber = 1; roundNumber < playerCount; roundNumber++) {
-      for (int i = 0; i < playerCount / 2; i++) {
-        addTournamentMatch(
-            tournament,
-            roundNumber,
-            i + 1,
-            rotation.get(i),
-            rotation.get(playerCount - 1 - i));
-      }
-      rotateRoundRobinPlayers(rotation);
-    }
-  }
-
-  private void rotateRoundRobinPlayers(List<Player> players) {
-    Player lastPlayer = players.remove(players.size() - 1);
-    players.add(1, lastPlayer);
-  }
-
-  private void addTournamentMatch(
-      Tournament tournament,
-      Integer roundNumber,
-      Integer matchNumber,
-      Player firstPlayer,
-      Player secondPlayer) {
-    tournament
-        .getMatches()
-        .add(
-            TournamentMatch.builder()
-                .tournament(tournament)
-                .roundNumber(roundNumber)
-                .matchNumber(matchNumber)
-                .firstPlayer(firstPlayer)
-                .secondPlayer(secondPlayer)
-                .status(TournamentMatchStatus.PENDING)
-                .createdAt(Instant.now(Clock.systemUTC()))
-                .build());
-  }
-
-  private List<Player> seededPlayers(Tournament tournament) {
-    return tournament.getParticipants().stream()
-        .sorted(Comparator.comparing(participant -> participant.getSeedNumber()))
-        .map(participant -> participant.getPlayer())
-        .toList();
   }
 
   private void validateMatchCanBeReported(
@@ -232,96 +173,7 @@ public class TournamentService {
   private void completeTournamentMatch(TournamentMatch tournamentMatch, Player winner) {
     tournamentMatch.setWinner(winner);
     tournamentMatch.setStatus(TournamentMatchStatus.COMPLETED);
-    tournamentMatch.setCompletedAt(Instant.now(Clock.systemUTC()));
-  }
-
-  private void progressTournament(Tournament tournament, Integer completedRoundNumber) {
-    if (tournament.getBracketType() == BracketType.ROUND_ROBIN) {
-      completeRoundRobinTournamentIfReady(tournament);
-      return;
-    }
-    progressSingleEliminationTournament(tournament, completedRoundNumber);
-  }
-
-  private void progressSingleEliminationTournament(
-      Tournament tournament, Integer completedRoundNumber) {
-    List<TournamentMatch> roundMatches = matchesInRound(tournament, completedRoundNumber);
-    if (hasPendingMatches(roundMatches)) {
-      return;
-    }
-
-    List<Player> winners = roundWinners(roundMatches);
-    if (winners.size() == FINALIST_COUNT) {
-      completeTournament(tournament, winners.get(0));
-      return;
-    }
-
-    Integer nextRoundNumber = completedRoundNumber + 1;
-    if (matchesInRound(tournament, nextRoundNumber).isEmpty()) {
-      createNextSingleEliminationRound(tournament, nextRoundNumber, winners);
-    }
-  }
-
-  private boolean hasPendingMatches(List<TournamentMatch> matches) {
-    return matches.stream().anyMatch(match -> match.getStatus() != TournamentMatchStatus.COMPLETED);
-  }
-
-  private List<Player> roundWinners(List<TournamentMatch> matches) {
-    return matches.stream()
-        .sorted(Comparator.comparing(TournamentMatch::getMatchNumber))
-        .map(TournamentMatch::getWinner)
-        .toList();
-  }
-
-  private void createNextSingleEliminationRound(
-      Tournament tournament, Integer roundNumber, List<Player> winners) {
-    for (int i = 0; i < winners.size(); i += 2) {
-      addTournamentMatch(tournament, roundNumber, (i / 2) + 1, winners.get(i), winners.get(i + 1));
-    }
-  }
-
-  private List<TournamentMatch> matchesInRound(Tournament tournament, Integer roundNumber) {
-    return tournament.getMatches().stream()
-        .filter(match -> match.getRoundNumber().equals(roundNumber))
-        .sorted(Comparator.comparing(TournamentMatch::getMatchNumber))
-        .toList();
-  }
-
-  private void completeRoundRobinTournamentIfReady(Tournament tournament) {
-    if (hasPendingMatches(tournament.getMatches())) {
-      return;
-    }
-
-    Map<Long, Integer> winsByPlayerId = winsByPlayerId(tournament);
-    Player winner =
-        tournament.getParticipants().stream()
-            .min(roundRobinRanking(winsByPlayerId))
-            .map(participant -> participant.getPlayer())
-            .orElseThrow();
-    completeTournament(tournament, winner);
-  }
-
-  private Map<Long, Integer> winsByPlayerId(Tournament tournament) {
-    Map<Long, Integer> winsByPlayerId = new LinkedHashMap<>();
-    seededPlayers(tournament).forEach(player -> winsByPlayerId.put(player.getPlayerId(), 0));
-    tournament
-        .getMatches()
-        .forEach(
-            match -> winsByPlayerId.computeIfPresent(match.getWinner().getPlayerId(), (id, wins) -> wins + 1));
-    return winsByPlayerId;
-  }
-
-  private Comparator<TournamentParticipant> roundRobinRanking(Map<Long, Integer> winsByPlayerId) {
-    return Comparator
-        .<TournamentParticipant>comparingInt(
-            participant -> -winsByPlayerId.getOrDefault(participant.getPlayer().getPlayerId(), 0))
-        .thenComparingInt(participant -> participant.getSeedNumber());
-  }
-
-  private void completeTournament(Tournament tournament, Player winner) {
-    tournament.setStatus(TournamentStatus.COMPLETED);
-    tournament.setWinner(winner);
-    tournament.setCompletedAt(Instant.now(Clock.systemUTC()));
+    tournamentMatch.setCompletedAt(Instant.now(clock));
   }
 
   private void validateRequest(CreateTournamentRequest request) {

--- a/src/main/java/com/emt/service/TournamentService.java
+++ b/src/main/java/com/emt/service/TournamentService.java
@@ -1,17 +1,30 @@
 package com.emt.service;
 
 import com.emt.entity.Player;
+import com.emt.entity.Tournament;
+import com.emt.entity.TournamentMatch;
+import com.emt.entity.TournamentParticipant;
 import com.emt.mapper.TournamentMapper;
 import com.emt.metrics.BusinessMetrics;
 import com.emt.model.exception.TournamentCreationException;
+import com.emt.model.request.CreateMatchRequest;
 import com.emt.model.request.CreateTournamentRequest;
 import com.emt.model.response.TournamentResponse;
+import com.emt.model.tournament.BracketType;
 import com.emt.model.tournament.SeedingMode;
+import com.emt.model.tournament.TournamentMatchStatus;
+import com.emt.model.tournament.TournamentStatus;
 import com.emt.repository.PlayerRepository;
+import com.emt.repository.TournamentMatchRepository;
 import com.emt.repository.TournamentRepository;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,10 +35,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class TournamentService {
 
   private static final List<Integer> SUPPORTED_PLAYER_COUNTS = List.of(2, 4, 8, 16);
+  private static final int FIRST_ROUND = 1;
+  private static final int FINALIST_COUNT = 1;
 
   private final PlayerRepository playerRepository;
   private final TournamentRepository tournamentRepository;
+  private final TournamentMatchRepository tournamentMatchRepository;
   private final TournamentMapper tournamentMapper;
+  private final MatchService matchService;
   private final BusinessMetrics businessMetrics;
 
   @Transactional(readOnly = true)
@@ -54,8 +71,257 @@ public class TournamentService {
     return response;
   }
 
+  @Transactional
+  public TournamentResponse startTournament(Long tournamentId) {
+    Tournament tournament = getTournament(tournamentId);
+    validateTournamentCanStart(tournament);
+
+    if (tournament.getBracketType() == BracketType.SINGLE_ELIMINATION) {
+      createSingleEliminationFirstRound(tournament);
+    } else {
+      createRoundRobinMatches(tournament);
+    }
+
+    tournament.setStatus(TournamentStatus.ACTIVE);
+    tournament.setStartedAt(Instant.now(Clock.systemUTC()));
+    return tournamentMapper.mapToResponse(tournamentRepository.save(tournament));
+  }
+
+  @Transactional
+  public TournamentResponse reportTournamentMatchResult(Long tournamentMatchId, Long winnerId) {
+    TournamentMatch tournamentMatch = getTournamentMatch(tournamentMatchId);
+    Tournament tournament = tournamentMatch.getTournament();
+    validateMatchCanBeReported(tournament, tournamentMatch, winnerId);
+
+    Player winner = playerInMatch(tournamentMatch, winnerId);
+    Player loser = loserInMatch(tournamentMatch, winnerId);
+    matchService.createMatch(
+        CreateMatchRequest.builder()
+            .winnerId(winner.getPlayerId())
+            .loserId(loser.getPlayerId())
+            .build());
+
+    completeTournamentMatch(tournamentMatch, winner);
+    progressTournament(tournament, tournamentMatch.getRoundNumber());
+
+    return tournamentMapper.mapToResponse(tournamentRepository.save(tournament));
+  }
+
   public List<Integer> supportedPlayerCounts() {
     return SUPPORTED_PLAYER_COUNTS;
+  }
+
+  private Tournament getTournament(Long tournamentId) {
+    return tournamentRepository
+        .findById(tournamentId)
+        .orElseThrow(() -> new TournamentCreationException("Tournament not found: " + tournamentId));
+  }
+
+  private TournamentMatch getTournamentMatch(Long tournamentMatchId) {
+    return tournamentMatchRepository
+        .findWithPlayersByTournamentMatchId(tournamentMatchId)
+        .orElseThrow(
+            () -> new TournamentCreationException("Tournament match not found: " + tournamentMatchId));
+  }
+
+  private void validateTournamentCanStart(Tournament tournament) {
+    if (tournament.getStatus() != TournamentStatus.DRAFT) {
+      throw new TournamentCreationException("Only draft tournaments can be started.");
+    }
+    if (!tournament.getMatches().isEmpty()) {
+      throw new TournamentCreationException("Tournament bracket has already been generated.");
+    }
+    if (tournament.getParticipants().size() != tournament.getPlayerCount()) {
+      throw new TournamentCreationException("Tournament roster is incomplete.");
+    }
+  }
+
+  private void createSingleEliminationFirstRound(Tournament tournament) {
+    List<Player> seededPlayers = seededPlayers(tournament);
+    for (int i = 0; i < seededPlayers.size() / 2; i++) {
+      addTournamentMatch(
+          tournament,
+          FIRST_ROUND,
+          i + 1,
+          seededPlayers.get(i),
+          seededPlayers.get(seededPlayers.size() - 1 - i));
+    }
+  }
+
+  private void createRoundRobinMatches(Tournament tournament) {
+    List<Player> rotation = new ArrayList<>(seededPlayers(tournament));
+    int playerCount = rotation.size();
+
+    for (int roundNumber = 1; roundNumber < playerCount; roundNumber++) {
+      for (int i = 0; i < playerCount / 2; i++) {
+        addTournamentMatch(
+            tournament,
+            roundNumber,
+            i + 1,
+            rotation.get(i),
+            rotation.get(playerCount - 1 - i));
+      }
+      rotateRoundRobinPlayers(rotation);
+    }
+  }
+
+  private void rotateRoundRobinPlayers(List<Player> players) {
+    Player lastPlayer = players.remove(players.size() - 1);
+    players.add(1, lastPlayer);
+  }
+
+  private void addTournamentMatch(
+      Tournament tournament,
+      Integer roundNumber,
+      Integer matchNumber,
+      Player firstPlayer,
+      Player secondPlayer) {
+    tournament
+        .getMatches()
+        .add(
+            TournamentMatch.builder()
+                .tournament(tournament)
+                .roundNumber(roundNumber)
+                .matchNumber(matchNumber)
+                .firstPlayer(firstPlayer)
+                .secondPlayer(secondPlayer)
+                .status(TournamentMatchStatus.PENDING)
+                .createdAt(Instant.now(Clock.systemUTC()))
+                .build());
+  }
+
+  private List<Player> seededPlayers(Tournament tournament) {
+    return tournament.getParticipants().stream()
+        .sorted(Comparator.comparing(participant -> participant.getSeedNumber()))
+        .map(participant -> participant.getPlayer())
+        .toList();
+  }
+
+  private void validateMatchCanBeReported(
+      Tournament tournament, TournamentMatch tournamentMatch, Long winnerId) {
+    if (tournament.getStatus() != TournamentStatus.ACTIVE) {
+      throw new TournamentCreationException("Only active tournaments can receive match results.");
+    }
+    if (tournamentMatch.getStatus() != TournamentMatchStatus.PENDING) {
+      throw new TournamentCreationException("Tournament match has already been completed.");
+    }
+    if (!playerBelongsToMatch(tournamentMatch, winnerId)) {
+      throw new TournamentCreationException("Winner must be one of the tournament match players.");
+    }
+  }
+
+  private boolean playerBelongsToMatch(TournamentMatch tournamentMatch, Long playerId) {
+    return tournamentMatch.getFirstPlayer().getPlayerId().equals(playerId)
+        || tournamentMatch.getSecondPlayer().getPlayerId().equals(playerId);
+  }
+
+  private Player playerInMatch(TournamentMatch tournamentMatch, Long playerId) {
+    if (tournamentMatch.getFirstPlayer().getPlayerId().equals(playerId)) {
+      return tournamentMatch.getFirstPlayer();
+    }
+    return tournamentMatch.getSecondPlayer();
+  }
+
+  private Player loserInMatch(TournamentMatch tournamentMatch, Long winnerId) {
+    if (tournamentMatch.getFirstPlayer().getPlayerId().equals(winnerId)) {
+      return tournamentMatch.getSecondPlayer();
+    }
+    return tournamentMatch.getFirstPlayer();
+  }
+
+  private void completeTournamentMatch(TournamentMatch tournamentMatch, Player winner) {
+    tournamentMatch.setWinner(winner);
+    tournamentMatch.setStatus(TournamentMatchStatus.COMPLETED);
+    tournamentMatch.setCompletedAt(Instant.now(Clock.systemUTC()));
+  }
+
+  private void progressTournament(Tournament tournament, Integer completedRoundNumber) {
+    if (tournament.getBracketType() == BracketType.ROUND_ROBIN) {
+      completeRoundRobinTournamentIfReady(tournament);
+      return;
+    }
+    progressSingleEliminationTournament(tournament, completedRoundNumber);
+  }
+
+  private void progressSingleEliminationTournament(
+      Tournament tournament, Integer completedRoundNumber) {
+    List<TournamentMatch> roundMatches = matchesInRound(tournament, completedRoundNumber);
+    if (hasPendingMatches(roundMatches)) {
+      return;
+    }
+
+    List<Player> winners = roundWinners(roundMatches);
+    if (winners.size() == FINALIST_COUNT) {
+      completeTournament(tournament, winners.get(0));
+      return;
+    }
+
+    Integer nextRoundNumber = completedRoundNumber + 1;
+    if (matchesInRound(tournament, nextRoundNumber).isEmpty()) {
+      createNextSingleEliminationRound(tournament, nextRoundNumber, winners);
+    }
+  }
+
+  private boolean hasPendingMatches(List<TournamentMatch> matches) {
+    return matches.stream().anyMatch(match -> match.getStatus() != TournamentMatchStatus.COMPLETED);
+  }
+
+  private List<Player> roundWinners(List<TournamentMatch> matches) {
+    return matches.stream()
+        .sorted(Comparator.comparing(TournamentMatch::getMatchNumber))
+        .map(TournamentMatch::getWinner)
+        .toList();
+  }
+
+  private void createNextSingleEliminationRound(
+      Tournament tournament, Integer roundNumber, List<Player> winners) {
+    for (int i = 0; i < winners.size(); i += 2) {
+      addTournamentMatch(tournament, roundNumber, (i / 2) + 1, winners.get(i), winners.get(i + 1));
+    }
+  }
+
+  private List<TournamentMatch> matchesInRound(Tournament tournament, Integer roundNumber) {
+    return tournament.getMatches().stream()
+        .filter(match -> match.getRoundNumber().equals(roundNumber))
+        .sorted(Comparator.comparing(TournamentMatch::getMatchNumber))
+        .toList();
+  }
+
+  private void completeRoundRobinTournamentIfReady(Tournament tournament) {
+    if (hasPendingMatches(tournament.getMatches())) {
+      return;
+    }
+
+    Map<Long, Integer> winsByPlayerId = winsByPlayerId(tournament);
+    Player winner =
+        tournament.getParticipants().stream()
+            .min(roundRobinRanking(winsByPlayerId))
+            .map(participant -> participant.getPlayer())
+            .orElseThrow();
+    completeTournament(tournament, winner);
+  }
+
+  private Map<Long, Integer> winsByPlayerId(Tournament tournament) {
+    Map<Long, Integer> winsByPlayerId = new LinkedHashMap<>();
+    seededPlayers(tournament).forEach(player -> winsByPlayerId.put(player.getPlayerId(), 0));
+    tournament
+        .getMatches()
+        .forEach(
+            match -> winsByPlayerId.computeIfPresent(match.getWinner().getPlayerId(), (id, wins) -> wins + 1));
+    return winsByPlayerId;
+  }
+
+  private Comparator<TournamentParticipant> roundRobinRanking(Map<Long, Integer> winsByPlayerId) {
+    return Comparator
+        .<TournamentParticipant>comparingInt(
+            participant -> -winsByPlayerId.getOrDefault(participant.getPlayer().getPlayerId(), 0))
+        .thenComparingInt(participant -> participant.getSeedNumber());
+  }
+
+  private void completeTournament(Tournament tournament, Player winner) {
+    tournament.setStatus(TournamentStatus.COMPLETED);
+    tournament.setWinner(winner);
+    tournament.setCompletedAt(Instant.now(Clock.systemUTC()));
   }
 
   private void validateRequest(CreateTournamentRequest request) {

--- a/src/main/java/com/emt/service/tournament/RoundRobinBracketStrategy.java
+++ b/src/main/java/com/emt/service/tournament/RoundRobinBracketStrategy.java
@@ -1,0 +1,105 @@
+package com.emt.service.tournament;
+
+import com.emt.entity.Player;
+import com.emt.entity.Tournament;
+import com.emt.entity.TournamentMatch;
+import com.emt.entity.TournamentParticipant;
+import com.emt.model.tournament.BracketType;
+import com.emt.model.tournament.TournamentMatchStatus;
+import com.emt.model.tournament.TournamentStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoundRobinBracketStrategy implements TournamentBracketStrategy {
+
+  private final Clock clock;
+  private final TournamentMatchFactory tournamentMatchFactory;
+
+  @Override
+  public BracketType bracketType() {
+    return BracketType.ROUND_ROBIN;
+  }
+
+  @Override
+  public void createInitialMatches(Tournament tournament) {
+    List<Player> rotation = new ArrayList<>(seededPlayers(tournament));
+    int playerCount = rotation.size();
+
+    for (int roundNumber = 1; roundNumber < playerCount; roundNumber++) {
+      for (int i = 0; i < playerCount / 2; i++) {
+        tournamentMatchFactory.addMatch(
+            tournament,
+            roundNumber,
+            i + 1,
+            rotation.get(i),
+            rotation.get(playerCount - 1 - i));
+      }
+      rotateRoundRobinPlayers(rotation);
+    }
+  }
+
+  @Override
+  public void progressAfterResult(Tournament tournament, Integer completedRoundNumber) {
+    if (hasPendingMatches(tournament.getMatches())) {
+      return;
+    }
+
+    Map<Long, Integer> winsByPlayerId = winsByPlayerId(tournament);
+    Player winner =
+        tournament.getParticipants().stream()
+            .min(roundRobinRanking(winsByPlayerId))
+            .map(participant -> participant.getPlayer())
+            .orElseThrow();
+    completeTournament(tournament, winner);
+  }
+
+  private void rotateRoundRobinPlayers(List<Player> players) {
+    Player lastPlayer = players.remove(players.size() - 1);
+    players.add(1, lastPlayer);
+  }
+
+  private List<Player> seededPlayers(Tournament tournament) {
+    return tournament.getParticipants().stream()
+        .sorted(Comparator.comparing(participant -> participant.getSeedNumber()))
+        .map(participant -> participant.getPlayer())
+        .toList();
+  }
+
+  private boolean hasPendingMatches(List<TournamentMatch> matches) {
+    return matches.stream().anyMatch(match -> match.getStatus() != TournamentMatchStatus.COMPLETED);
+  }
+
+  private Map<Long, Integer> winsByPlayerId(Tournament tournament) {
+    Map<Long, Integer> winsByPlayerId = new LinkedHashMap<>();
+    seededPlayers(tournament).forEach(player -> winsByPlayerId.put(player.getPlayerId(), 0));
+    tournament
+        .getMatches()
+        .forEach(
+            match ->
+                winsByPlayerId.computeIfPresent(
+                    match.getWinner().getPlayerId(), (id, wins) -> wins + 1));
+    return winsByPlayerId;
+  }
+
+  private Comparator<TournamentParticipant> roundRobinRanking(Map<Long, Integer> winsByPlayerId) {
+    return Comparator
+        .<TournamentParticipant>comparingInt(
+            participant -> -winsByPlayerId.getOrDefault(participant.getPlayer().getPlayerId(), 0))
+        .thenComparingInt(participant -> participant.getSeedNumber());
+  }
+
+  private void completeTournament(Tournament tournament, Player winner) {
+    tournament.setStatus(TournamentStatus.COMPLETED);
+    tournament.setWinner(winner);
+    tournament.setCompletedAt(Instant.now(clock));
+  }
+}

--- a/src/main/java/com/emt/service/tournament/SingleEliminationBracketStrategy.java
+++ b/src/main/java/com/emt/service/tournament/SingleEliminationBracketStrategy.java
@@ -1,0 +1,100 @@
+package com.emt.service.tournament;
+
+import com.emt.entity.Player;
+import com.emt.entity.Tournament;
+import com.emt.entity.TournamentMatch;
+import com.emt.model.tournament.BracketType;
+import com.emt.model.tournament.TournamentMatchStatus;
+import com.emt.model.tournament.TournamentStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SingleEliminationBracketStrategy implements TournamentBracketStrategy {
+
+  private static final int FIRST_ROUND = 1;
+  private static final int FINALIST_COUNT = 1;
+
+  private final Clock clock;
+  private final TournamentMatchFactory tournamentMatchFactory;
+
+  @Override
+  public BracketType bracketType() {
+    return BracketType.SINGLE_ELIMINATION;
+  }
+
+  @Override
+  public void createInitialMatches(Tournament tournament) {
+    List<Player> seededPlayers = seededPlayers(tournament);
+    for (int i = 0; i < seededPlayers.size() / 2; i++) {
+      tournamentMatchFactory.addMatch(
+          tournament,
+          FIRST_ROUND,
+          i + 1,
+          seededPlayers.get(i),
+          seededPlayers.get(seededPlayers.size() - 1 - i));
+    }
+  }
+
+  @Override
+  public void progressAfterResult(Tournament tournament, Integer completedRoundNumber) {
+    List<TournamentMatch> roundMatches = matchesInRound(tournament, completedRoundNumber);
+    if (hasPendingMatches(roundMatches)) {
+      return;
+    }
+
+    List<Player> winners = roundWinners(roundMatches);
+    if (winners.size() == FINALIST_COUNT) {
+      completeTournament(tournament, winners.get(0));
+      return;
+    }
+
+    Integer nextRoundNumber = completedRoundNumber + 1;
+    if (matchesInRound(tournament, nextRoundNumber).isEmpty()) {
+      createNextRound(tournament, nextRoundNumber, winners);
+    }
+  }
+
+  private List<Player> seededPlayers(Tournament tournament) {
+    return tournament.getParticipants().stream()
+        .sorted(Comparator.comparing(participant -> participant.getSeedNumber()))
+        .map(participant -> participant.getPlayer())
+        .toList();
+  }
+
+  private boolean hasPendingMatches(List<TournamentMatch> matches) {
+    return matches.stream().anyMatch(match -> match.getStatus() != TournamentMatchStatus.COMPLETED);
+  }
+
+  private List<Player> roundWinners(List<TournamentMatch> matches) {
+    return matches.stream()
+        .sorted(Comparator.comparing(TournamentMatch::getMatchNumber))
+        .map(TournamentMatch::getWinner)
+        .toList();
+  }
+
+  private void createNextRound(Tournament tournament, Integer roundNumber, List<Player> winners) {
+    for (int i = 0; i < winners.size(); i += 2) {
+      tournamentMatchFactory.addMatch(
+          tournament, roundNumber, (i / 2) + 1, winners.get(i), winners.get(i + 1));
+    }
+  }
+
+  private List<TournamentMatch> matchesInRound(Tournament tournament, Integer roundNumber) {
+    return tournament.getMatches().stream()
+        .filter(match -> match.getRoundNumber().equals(roundNumber))
+        .sorted(Comparator.comparing(TournamentMatch::getMatchNumber))
+        .toList();
+  }
+
+  private void completeTournament(Tournament tournament, Player winner) {
+    tournament.setStatus(TournamentStatus.COMPLETED);
+    tournament.setWinner(winner);
+    tournament.setCompletedAt(Instant.now(clock));
+  }
+}

--- a/src/main/java/com/emt/service/tournament/TournamentBracketStrategy.java
+++ b/src/main/java/com/emt/service/tournament/TournamentBracketStrategy.java
@@ -1,0 +1,13 @@
+package com.emt.service.tournament;
+
+import com.emt.entity.Tournament;
+import com.emt.model.tournament.BracketType;
+
+public interface TournamentBracketStrategy {
+
+  BracketType bracketType();
+
+  void createInitialMatches(Tournament tournament);
+
+  void progressAfterResult(Tournament tournament, Integer completedRoundNumber);
+}

--- a/src/main/java/com/emt/service/tournament/TournamentMatchFactory.java
+++ b/src/main/java/com/emt/service/tournament/TournamentMatchFactory.java
@@ -1,0 +1,37 @@
+package com.emt.service.tournament;
+
+import com.emt.entity.Player;
+import com.emt.entity.Tournament;
+import com.emt.entity.TournamentMatch;
+import com.emt.model.tournament.TournamentMatchStatus;
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TournamentMatchFactory {
+
+  private final Clock clock;
+
+  public void addMatch(
+      Tournament tournament,
+      Integer roundNumber,
+      Integer matchNumber,
+      Player firstPlayer,
+      Player secondPlayer) {
+    tournament
+        .getMatches()
+        .add(
+            TournamentMatch.builder()
+                .tournament(tournament)
+                .roundNumber(roundNumber)
+                .matchNumber(matchNumber)
+                .firstPlayer(firstPlayer)
+                .secondPlayer(secondPlayer)
+                .status(TournamentMatchStatus.PENDING)
+                .createdAt(Instant.now(clock))
+                .build());
+  }
+}

--- a/src/main/resources/db/migration/V08__add_tournament_engine.sql
+++ b/src/main/resources/db/migration/V08__add_tournament_engine.sql
@@ -1,0 +1,27 @@
+ALTER TABLE tournament
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT', 'ACTIVE', 'COMPLETED', 'CANCELLED')),
+    ADD COLUMN winner_id BIGINT REFERENCES player (player_id),
+    ADD COLUMN started_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN completed_at TIMESTAMP WITH TIME ZONE;
+
+CREATE TABLE tournament_match
+(
+    tournament_match_id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    tournament_id       BIGINT                   NOT NULL REFERENCES tournament (tournament_id) ON DELETE CASCADE,
+    round_number        INTEGER                  NOT NULL CHECK (round_number > 0),
+    match_number        INTEGER                  NOT NULL CHECK (match_number > 0),
+    first_player_id     BIGINT                   NOT NULL REFERENCES player (player_id),
+    second_player_id    BIGINT                   NOT NULL REFERENCES player (player_id),
+    winner_id           BIGINT REFERENCES player (player_id),
+    status              TEXT                     NOT NULL CHECK (status IN ('PENDING', 'COMPLETED')),
+    created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    completed_at        TIMESTAMP WITH TIME ZONE,
+    CONSTRAINT uq_tournament_match_slot UNIQUE (tournament_id, round_number, match_number),
+    CONSTRAINT chk_tournament_match_distinct_players CHECK (first_player_id <> second_player_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tournament_status ON tournament (status);
+CREATE INDEX IF NOT EXISTS idx_tournament_winner_id ON tournament (winner_id);
+CREATE INDEX IF NOT EXISTS idx_tournament_match_tournament_id ON tournament_match (tournament_id);
+CREATE INDEX IF NOT EXISTS idx_tournament_match_status ON tournament_match (status);
+CREATE INDEX IF NOT EXISTS idx_tournament_match_winner_id ON tournament_match (winner_id);

--- a/src/main/resources/static/styles/styles.css
+++ b/src/main/resources/static/styles/styles.css
@@ -388,3 +388,78 @@ th {
         overflow-x: auto;
     }
 }
+
+.tournament-meta,
+.tournament-actions,
+.winner-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.status-pill {
+    display: inline-flex;
+    width: fit-content;
+    align-items: center;
+    min-height: 30px;
+    padding: 0 10px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: #ffffff;
+    color: var(--accent-strong);
+    font-size: 0.86rem;
+    font-weight: 700;
+}
+
+.winner-banner {
+    padding: 12px 14px;
+    border: 1px solid var(--success-text);
+    border-radius: 6px;
+    background: var(--success-bg);
+    color: var(--success-text);
+    font-weight: 700;
+}
+
+.match-board {
+    display: grid;
+    gap: 12px;
+    margin-top: 18px;
+}
+
+.match-board h3,
+.match-label,
+.match-players {
+    margin: 0;
+}
+
+.match-card {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 14px;
+    align-items: center;
+    padding: 14px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: #ffffff;
+}
+
+.match-label {
+    color: var(--muted);
+    font-size: 0.86rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.match-players {
+    margin-top: 4px;
+    font-weight: 700;
+}
+
+@media (max-width: 720px) {
+    .match-card,
+    .winner-actions {
+        grid-template-columns: 1fr;
+        width: 100%;
+    }
+}

--- a/src/main/resources/static/styles/styles.css
+++ b/src/main/resources/static/styles/styles.css
@@ -457,9 +457,13 @@ th {
 }
 
 @media (max-width: 720px) {
-    .match-card,
-    .winner-actions {
+    .match-card {
         grid-template-columns: 1fr;
+        width: 100%;
+    }
+
+    .winner-actions {
+        flex-direction: column;
         width: 100%;
     }
 }

--- a/src/main/resources/templates/tournaments.html
+++ b/src/main/resources/templates/tournaments.html
@@ -95,7 +95,7 @@
 
     <section class="panel">
         <div class="section-title">
-            <h2>Active tournament setups</h2>
+            <h2>Tournament desk</h2>
             <span th:text="${#lists.size(tournaments)} + ' tournaments'">0 tournaments</span>
         </div>
 
@@ -113,8 +113,20 @@
                             Rules
                         </p>
                     </div>
-                    <span th:text="${tournament.seedingMode.displayName} + ' seeding'">Manual seeding</span>
+                    <div class="tournament-meta">
+                        <span class="status-pill" th:text="${tournament.status.displayName}">Draft</span>
+                        <span th:text="${tournament.seedingMode.displayName} + ' seeding'">Manual seeding</span>
+                    </div>
                 </div>
+
+                <div class="tournament-actions" th:if="${tournament.status.name() == 'DRAFT'}">
+                    <form th:action="@{/tournaments/{id}/start(id=${tournament.tournamentId})}" method="post">
+                        <button type="submit">Start tournament</button>
+                    </form>
+                </div>
+
+                <p class="winner-banner" th:if="${tournament.winnerNickname != null}"
+                   th:text="${'Winner: ' + tournament.winnerNickname}">Winner: Player</p>
 
                 <ol class="bracket-grid">
                     <li th:each="participant : ${tournament.participants}" class="bracket-slot">
@@ -122,6 +134,35 @@
                         <span class="nickname" th:text="${participant.nickname}">Player</span>
                     </li>
                 </ol>
+
+                <div class="match-board" th:if="${!#lists.isEmpty(tournament.matches)}">
+                    <h3>Bracket matches</h3>
+                    <article class="match-card" th:each="match : ${tournament.matches}">
+                        <div>
+                            <p class="match-label"
+                               th:text="${'Round ' + match.roundNumber + ' · Match ' + match.matchNumber}">
+                                Round 1 · Match 1
+                            </p>
+                            <p class="match-players"
+                               th:text="${match.firstPlayerNickname + ' vs ' + match.secondPlayerNickname}">
+                                First vs Second
+                            </p>
+                            <p class="muted-copy" th:if="${match.winnerNickname != null}"
+                               th:text="${'Winner: ' + match.winnerNickname}">Winner: Player</p>
+                        </div>
+                        <form class="winner-actions"
+                              th:if="${match.status.name() == 'PENDING' && tournament.status.name() == 'ACTIVE'}"
+                              th:action="@{/tournaments/matches/{matchId}/report(matchId=${match.tournamentMatchId})}"
+                              method="post">
+                            <button type="submit" name="winnerId" th:value="${match.firstPlayerId}"
+                                    th:text="${match.firstPlayerNickname + ' wins'}">First wins</button>
+                            <button type="submit" name="winnerId" th:value="${match.secondPlayerId}"
+                                    th:text="${match.secondPlayerNickname + ' wins'}">Second wins</button>
+                        </form>
+                        <span class="status-pill" th:if="${match.status.name() == 'COMPLETED'}"
+                              th:text="${match.status.displayName}">Completed</span>
+                    </article>
+                </div>
             </article>
         </div>
     </section>

--- a/src/test/integration/java/com/emt/controller/TournamentControllerIT.java
+++ b/src/test/integration/java/com/emt/controller/TournamentControllerIT.java
@@ -16,6 +16,7 @@ import com.emt.model.response.TournamentResponse;
 import com.emt.model.tournament.BracketType;
 import com.emt.model.tournament.GameFormat;
 import com.emt.model.tournament.SeedingMode;
+import com.emt.model.tournament.TournamentStatus;
 import com.emt.repository.TournamentRepository;
 import com.emt.service.PlayerService;
 import com.emt.service.TournamentService;
@@ -109,6 +110,47 @@ class TournamentControllerIT extends ITBase {
     assertThat(tournaments.get(0).participants())
         .extracting(participant -> participant.seedNumber())
         .containsExactly(1, 2);
+  }
+
+
+  @Test
+  void tournamentEngine_ShouldStartAndRecordFinalMatch() throws Exception {
+    Long firstPlayerId = createPlayer("EngineOne");
+    Long secondPlayerId = createPlayer("EngineTwo");
+    TournamentResponse tournament =
+        tournamentService.createTournament(
+            CreateTournamentRequest.builder()
+                .name("Engine Cup")
+                .playerCount(2)
+                .seedingMode(SeedingMode.MANUAL)
+                .gameFormat(GameFormat.BO1)
+                .winningPoints(11)
+                .bracketType(BracketType.SINGLE_ELIMINATION)
+                .playerIds(List.of(firstPlayerId, secondPlayerId))
+                .build());
+
+    mockMvc
+        .perform(post(TOURNAMENTS_PATH + "/" + tournament.tournamentId() + "/start"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(TOURNAMENTS_PATH))
+        .andExpect(flash().attribute("message", "Tournament started successfully!"));
+
+    TournamentResponse startedTournament = tournamentService.getAllTournaments().get(0);
+    Long tournamentMatchId = startedTournament.matches().get(0).tournamentMatchId();
+
+    mockMvc
+        .perform(
+            post(TOURNAMENTS_PATH + "/matches/" + tournamentMatchId + "/report")
+                .param("winnerId", String.valueOf(firstPlayerId)))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(TOURNAMENTS_PATH))
+        .andExpect(flash().attribute("message", "Tournament match recorded successfully!"));
+
+    TournamentResponse completedTournament = tournamentService.getAllTournaments().get(0);
+
+    assertThat(completedTournament.status()).isEqualTo(TournamentStatus.COMPLETED);
+    assertThat(completedTournament.winnerNickname()).isEqualTo("EngineOne");
+    assertThat(completedTournament.matches()).hasSize(1);
   }
 
   @Test

--- a/src/test/integration/java/com/emt/controller/TournamentControllerIT.java
+++ b/src/test/integration/java/com/emt/controller/TournamentControllerIT.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.emt.ITBase;
 import com.emt.model.request.CreatePlayerRequest;
 import com.emt.model.request.CreateTournamentRequest;
+import com.emt.model.response.TournamentMatchResponse;
 import com.emt.model.response.TournamentResponse;
 import com.emt.model.tournament.BracketType;
 import com.emt.model.tournament.GameFormat;
@@ -31,6 +32,8 @@ class TournamentControllerIT extends ITBase {
 
   private static final String TOURNAMENTS_PATH = "/tournaments";
   private static final String TOURNAMENTS_VIEW = "tournaments";
+  private static final String START_PATH_SUFFIX = "/start";
+  private static final String MESSAGE_ATTRIBUTE = "message";
 
   private final MockMvc mockMvc;
   private final PlayerService playerService;
@@ -69,7 +72,7 @@ class TournamentControllerIT extends ITBase {
                 .param("playerIds", String.valueOf(firstPlayerId), String.valueOf(secondPlayerId)))
         .andExpect(status().is3xxRedirection())
         .andExpect(redirectedUrl(TOURNAMENTS_PATH))
-        .andExpect(flash().attribute("message", "Tournament created successfully!"));
+        .andExpect(flash().attribute(MESSAGE_ATTRIBUTE, "Tournament created successfully!"));
 
     List<TournamentResponse> tournaments = tournamentService.getAllTournaments();
 
@@ -130,10 +133,10 @@ class TournamentControllerIT extends ITBase {
                 .build());
 
     mockMvc
-        .perform(post(TOURNAMENTS_PATH + "/" + tournament.tournamentId() + "/start"))
+        .perform(post(TOURNAMENTS_PATH + "/" + tournament.tournamentId() + START_PATH_SUFFIX))
         .andExpect(status().is3xxRedirection())
         .andExpect(redirectedUrl(TOURNAMENTS_PATH))
-        .andExpect(flash().attribute("message", "Tournament started successfully!"));
+        .andExpect(flash().attribute(MESSAGE_ATTRIBUTE, "Tournament started successfully!"));
 
     TournamentResponse startedTournament = tournamentService.getAllTournaments().get(0);
     Long tournamentMatchId = startedTournament.matches().get(0).tournamentMatchId();
@@ -144,13 +147,127 @@ class TournamentControllerIT extends ITBase {
                 .param("winnerId", String.valueOf(firstPlayerId)))
         .andExpect(status().is3xxRedirection())
         .andExpect(redirectedUrl(TOURNAMENTS_PATH))
-        .andExpect(flash().attribute("message", "Tournament match recorded successfully!"));
+        .andExpect(flash().attribute(MESSAGE_ATTRIBUTE, "Tournament match recorded successfully!"));
 
     TournamentResponse completedTournament = tournamentService.getAllTournaments().get(0);
 
     assertThat(completedTournament.status()).isEqualTo(TournamentStatus.COMPLETED);
     assertThat(completedTournament.winnerNickname()).isEqualTo("EngineOne");
     assertThat(completedTournament.matches()).hasSize(1);
+  }
+
+
+  @Test
+  void roundRobinTournamentEngine_ShouldCompleteViaHttpFlow() throws Exception {
+    Long firstPlayerId = createPlayer("RobinEngineOne");
+    Long secondPlayerId = createPlayer("RobinEngineTwo");
+    Long thirdPlayerId = createPlayer("RobinEngineThree");
+    Long fourthPlayerId = createPlayer("RobinEngineFour");
+    TournamentResponse tournament =
+        tournamentService.createTournament(
+            CreateTournamentRequest.builder()
+                .name("Round Robin Engine Cup")
+                .playerCount(4)
+                .seedingMode(SeedingMode.MANUAL)
+                .gameFormat(GameFormat.BO1)
+                .winningPoints(11)
+                .bracketType(BracketType.ROUND_ROBIN)
+                .playerIds(List.of(firstPlayerId, secondPlayerId, thirdPlayerId, fourthPlayerId))
+                .build());
+
+    mockMvc
+        .perform(post(TOURNAMENTS_PATH + "/" + tournament.tournamentId() + START_PATH_SUFFIX))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(TOURNAMENTS_PATH))
+        .andExpect(flash().attribute(MESSAGE_ATTRIBUTE, "Tournament started successfully!"));
+
+    TournamentResponse startedTournament = tournamentService.getAllTournaments().get(0);
+
+    assertThat(startedTournament.matches()).hasSize(6);
+
+    for (TournamentMatchResponse match : startedTournament.matches()) {
+      Long winnerId = roundRobinWinnerFor(match, firstPlayerId);
+      mockMvc
+          .perform(
+              post(TOURNAMENTS_PATH + "/matches/" + match.tournamentMatchId() + "/report")
+                  .param("winnerId", String.valueOf(winnerId)))
+          .andExpect(status().is3xxRedirection())
+          .andExpect(redirectedUrl(TOURNAMENTS_PATH))
+          .andExpect(flash().attribute(MESSAGE_ATTRIBUTE, "Tournament match recorded successfully!"));
+    }
+
+    TournamentResponse completedTournament = tournamentService.getAllTournaments().get(0);
+
+    assertThat(completedTournament.status()).isEqualTo(TournamentStatus.COMPLETED);
+    assertThat(completedTournament.winnerNickname()).isEqualTo("RobinEngineOne");
+  }
+
+  @Test
+  void startTournament_withNonDraftTournament_ShouldRedirectWithError() throws Exception {
+    Long firstPlayerId = createPlayer("NonDraftOne");
+    Long secondPlayerId = createPlayer("NonDraftTwo");
+    TournamentResponse tournament =
+        tournamentService.createTournament(
+            CreateTournamentRequest.builder()
+                .name("Non Draft Cup")
+                .playerCount(2)
+                .seedingMode(SeedingMode.MANUAL)
+                .gameFormat(GameFormat.BO1)
+                .winningPoints(11)
+                .bracketType(BracketType.SINGLE_ELIMINATION)
+                .playerIds(List.of(firstPlayerId, secondPlayerId))
+                .build());
+
+    mockMvc
+        .perform(post(TOURNAMENTS_PATH + "/" + tournament.tournamentId() + START_PATH_SUFFIX))
+        .andExpect(status().is3xxRedirection());
+
+    mockMvc
+        .perform(post(TOURNAMENTS_PATH + "/" + tournament.tournamentId() + START_PATH_SUFFIX))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(TOURNAMENTS_PATH))
+        .andExpect(
+            flash()
+                .attribute(
+                    "error",
+                    "Tournament creation failed: Only draft tournaments can be started."));
+  }
+
+  @Test
+  void reportTournamentMatch_withInvalidWinner_ShouldRedirectWithError() throws Exception {
+    Long firstPlayerId = createPlayer("InvalidWinnerOne");
+    Long secondPlayerId = createPlayer("InvalidWinnerTwo");
+    Long invalidWinnerId = createPlayer("InvalidWinnerThree");
+    TournamentResponse tournament =
+        tournamentService.createTournament(
+            CreateTournamentRequest.builder()
+                .name("Invalid Winner Cup")
+                .playerCount(2)
+                .seedingMode(SeedingMode.MANUAL)
+                .gameFormat(GameFormat.BO1)
+                .winningPoints(11)
+                .bracketType(BracketType.SINGLE_ELIMINATION)
+                .playerIds(List.of(firstPlayerId, secondPlayerId))
+                .build());
+
+    mockMvc
+        .perform(post(TOURNAMENTS_PATH + "/" + tournament.tournamentId() + START_PATH_SUFFIX))
+        .andExpect(status().is3xxRedirection());
+
+    TournamentResponse startedTournament = tournamentService.getAllTournaments().get(0);
+    Long tournamentMatchId = startedTournament.matches().get(0).tournamentMatchId();
+
+    mockMvc
+        .perform(
+            post(TOURNAMENTS_PATH + "/matches/" + tournamentMatchId + "/report")
+                .param("winnerId", String.valueOf(invalidWinnerId)))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(TOURNAMENTS_PATH))
+        .andExpect(
+            flash()
+                .attribute(
+                    "error",
+                    "Tournament creation failed: Winner must be one of the tournament match players."));
   }
 
   @Test
@@ -173,6 +290,14 @@ class TournamentControllerIT extends ITBase {
         .andExpect(flash().attributeExists("error"));
 
     assertThat(tournamentRepository.findAll()).isEmpty();
+  }
+
+  private Long roundRobinWinnerFor(TournamentMatchResponse match, Long preferredWinnerId) {
+    if (match.firstPlayerId().equals(preferredWinnerId)
+        || match.secondPlayerId().equals(preferredWinnerId)) {
+      return preferredWinnerId;
+    }
+    return match.firstPlayerId();
   }
 
   private Long createPlayer(String nickname) {

--- a/src/test/unit/java/com/emt/service/TournamentServiceTest.java
+++ b/src/test/unit/java/com/emt/service/TournamentServiceTest.java
@@ -23,16 +23,20 @@ import com.emt.model.tournament.TournamentStatus;
 import com.emt.repository.PlayerRepository;
 import com.emt.repository.TournamentMatchRepository;
 import com.emt.repository.TournamentRepository;
+import com.emt.service.tournament.RoundRobinBracketStrategy;
+import com.emt.service.tournament.SingleEliminationBracketStrategy;
+import com.emt.service.tournament.TournamentMatchFactory;
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,10 +48,30 @@ class TournamentServiceTest {
   @Mock private PlayerRepository playerRepository;
   @Mock private TournamentRepository tournamentRepository;
   @Mock private TournamentMatchRepository tournamentMatchRepository;
-  @Spy private TournamentMapper tournamentMapper;
   @Mock private MatchService matchService;
   @Mock private BusinessMetrics businessMetrics;
-  @InjectMocks private TournamentService tournamentService;
+
+  private TournamentService tournamentService;
+
+  @BeforeEach
+  void setUp() {
+    Clock clock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC);
+    TournamentMapper tournamentMapper = new TournamentMapper();
+    TournamentMatchFactory tournamentMatchFactory = new TournamentMatchFactory(clock);
+
+    tournamentService =
+        new TournamentService(
+            playerRepository,
+            tournamentRepository,
+            tournamentMatchRepository,
+            tournamentMapper,
+            matchService,
+            businessMetrics,
+            clock,
+            List.of(
+                new SingleEliminationBracketStrategy(clock, tournamentMatchFactory),
+                new RoundRobinBracketStrategy(clock, tournamentMatchFactory)));
+  }
 
   @Test
   void createTournament_withManualSeeding_ShouldPersistSeededRoster() {
@@ -202,6 +226,55 @@ class TournamentServiceTest {
     assertThat(response.matches())
         .extracting(match -> match.roundNumber())
         .containsExactly(1, 1, 2, 2, 3, 3);
+  }
+
+
+  @Test
+  void startTournament_withNonDraftStatus_ShouldThrowException() {
+    Tournament tournament =
+        tournament(
+            13L,
+            2,
+            BracketType.SINGLE_ELIMINATION,
+            List.of(player(1L, FIRST_PLAYER), player(2L, SECOND_PLAYER)));
+    tournament.setStatus(TournamentStatus.ACTIVE);
+
+    given(tournamentRepository.findById(13L)).willReturn(Optional.of(tournament));
+
+    assertThatThrownBy(() -> tournamentService.startTournament(13L))
+        .isInstanceOf(TournamentCreationException.class)
+        .hasMessageContaining("Only draft tournaments can be started.");
+  }
+
+  @Test
+  void startTournament_withExistingMatches_ShouldThrowException() {
+    Player firstPlayer = player(1L, FIRST_PLAYER);
+    Player secondPlayer = player(2L, SECOND_PLAYER);
+    Tournament tournament =
+        tournament(14L, 2, BracketType.SINGLE_ELIMINATION, List.of(firstPlayer, secondPlayer));
+    tournament.getMatches().add(tournamentMatch(21L, tournament, firstPlayer, secondPlayer));
+
+    given(tournamentRepository.findById(14L)).willReturn(Optional.of(tournament));
+
+    assertThatThrownBy(() -> tournamentService.startTournament(14L))
+        .isInstanceOf(TournamentCreationException.class)
+        .hasMessageContaining("Tournament bracket has already been generated.");
+  }
+
+  @Test
+  void startTournament_withIncompleteRoster_ShouldThrowException() {
+    Tournament tournament =
+        tournament(
+            15L,
+            4,
+            BracketType.SINGLE_ELIMINATION,
+            List.of(player(1L, FIRST_PLAYER), player(2L, SECOND_PLAYER)));
+
+    given(tournamentRepository.findById(15L)).willReturn(Optional.of(tournament));
+
+    assertThatThrownBy(() -> tournamentService.startTournament(15L))
+        .isInstanceOf(TournamentCreationException.class)
+        .hasMessageContaining("Tournament roster is incomplete.");
   }
 
   @Test

--- a/src/test/unit/java/com/emt/service/TournamentServiceTest.java
+++ b/src/test/unit/java/com/emt/service/TournamentServiceTest.java
@@ -2,11 +2,14 @@ package com.emt.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.emt.entity.Player;
 import com.emt.entity.Tournament;
+import com.emt.entity.TournamentMatch;
+import com.emt.entity.TournamentParticipant;
 import com.emt.mapper.TournamentMapper;
 import com.emt.metrics.BusinessMetrics;
 import com.emt.model.exception.TournamentCreationException;
@@ -15,11 +18,15 @@ import com.emt.model.response.TournamentResponse;
 import com.emt.model.tournament.BracketType;
 import com.emt.model.tournament.GameFormat;
 import com.emt.model.tournament.SeedingMode;
+import com.emt.model.tournament.TournamentMatchStatus;
+import com.emt.model.tournament.TournamentStatus;
 import com.emt.repository.PlayerRepository;
+import com.emt.repository.TournamentMatchRepository;
 import com.emt.repository.TournamentRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -36,7 +43,9 @@ class TournamentServiceTest {
 
   @Mock private PlayerRepository playerRepository;
   @Mock private TournamentRepository tournamentRepository;
+  @Mock private TournamentMatchRepository tournamentMatchRepository;
   @Spy private TournamentMapper tournamentMapper;
+  @Mock private MatchService matchService;
   @Mock private BusinessMetrics businessMetrics;
   @InjectMocks private TournamentService tournamentService;
 
@@ -144,6 +153,78 @@ class TournamentServiceTest {
         .hasMessageContaining("Expected 4 players");
   }
 
+
+  @Test
+  void startTournament_withSingleElimination_ShouldGenerateSeededFirstRound() {
+    Player firstPlayer = player(1L, "SeedOne");
+    Player secondPlayer = player(2L, "SeedTwo");
+    Player thirdPlayer = player(3L, "SeedThree");
+    Player fourthPlayer = player(4L, "SeedFour");
+    Tournament tournament =
+        tournament(
+            10L,
+            4,
+            BracketType.SINGLE_ELIMINATION,
+            List.of(firstPlayer, secondPlayer, thirdPlayer, fourthPlayer));
+
+    given(tournamentRepository.findById(10L)).willReturn(Optional.of(tournament));
+    given(tournamentRepository.save(any(Tournament.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+    TournamentResponse response = tournamentService.startTournament(10L);
+
+    assertThat(response.status()).isEqualTo(TournamentStatus.ACTIVE);
+    assertThat(response.matches()).hasSize(2);
+    assertThat(response.matches())
+        .extracting(match -> match.firstPlayerNickname() + " vs " + match.secondPlayerNickname())
+        .containsExactly("SeedOne vs SeedFour", "SeedTwo vs SeedThree");
+  }
+
+  @Test
+  void startTournament_withRoundRobin_ShouldGenerateEveryPairAcrossRounds() {
+    Player firstPlayer = player(1L, "RobinOne");
+    Player secondPlayer = player(2L, "RobinTwo");
+    Player thirdPlayer = player(3L, "RobinThree");
+    Player fourthPlayer = player(4L, "RobinFour");
+    Tournament tournament =
+        tournament(
+            11L,
+            4,
+            BracketType.ROUND_ROBIN,
+            List.of(firstPlayer, secondPlayer, thirdPlayer, fourthPlayer));
+
+    given(tournamentRepository.findById(11L)).willReturn(Optional.of(tournament));
+    given(tournamentRepository.save(any(Tournament.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+    TournamentResponse response = tournamentService.startTournament(11L);
+
+    assertThat(response.status()).isEqualTo(TournamentStatus.ACTIVE);
+    assertThat(response.matches()).hasSize(6);
+    assertThat(response.matches())
+        .extracting(match -> match.roundNumber())
+        .containsExactly(1, 1, 2, 2, 3, 3);
+  }
+
+  @Test
+  void reportTournamentMatchResult_withFinalSingleEliminationMatch_ShouldCompleteTournament() {
+    Player firstPlayer = player(1L, FIRST_PLAYER);
+    Player secondPlayer = player(2L, SECOND_PLAYER);
+    Tournament tournament = tournament(12L, 2, BracketType.SINGLE_ELIMINATION, List.of(firstPlayer, secondPlayer));
+    tournament.setStatus(TournamentStatus.ACTIVE);
+    TournamentMatch tournamentMatch = tournamentMatch(20L, tournament, firstPlayer, secondPlayer);
+    tournament.getMatches().add(tournamentMatch);
+
+    given(tournamentMatchRepository.findWithPlayersByTournamentMatchId(20L))
+        .willReturn(Optional.of(tournamentMatch));
+    given(tournamentRepository.save(any(Tournament.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+    TournamentResponse response = tournamentService.reportTournamentMatchResult(20L, 1L);
+
+    assertThat(response.status()).isEqualTo(TournamentStatus.COMPLETED);
+    assertThat(response.winnerNickname()).isEqualTo(FIRST_PLAYER);
+    assertThat(response.matches().get(0).status()).isEqualTo(TournamentMatchStatus.COMPLETED);
+    verify(matchService).createMatch(any());
+  }
+
   @Test
   void getAllTournaments_ShouldReturnTournamentResponses() {
     Player firstPlayer = player(1L, FIRST_PLAYER);
@@ -161,7 +242,7 @@ class TournamentServiceTest {
     tournament
         .getParticipants()
         .add(
-            com.emt.entity.TournamentParticipant.builder()
+            TournamentParticipant.builder()
                 .tournament(tournament)
                 .player(firstPlayer)
                 .seedNumber(1)
@@ -174,6 +255,47 @@ class TournamentServiceTest {
     assertThat(tournaments).hasSize(1);
     assertThat(tournaments.get(0).name()).isEqualTo("Stored Tournament");
     assertThat(tournaments.get(0).participants()).hasSize(1);
+  }
+
+  private Tournament tournament(
+      Long tournamentId, Integer playerCount, BracketType bracketType, List<Player> players) {
+    Tournament tournament =
+        Tournament.builder()
+            .tournamentId(tournamentId)
+            .name("Stored Tournament")
+            .playerCount(playerCount)
+            .seedingMode(SeedingMode.MANUAL)
+            .gameFormat(GameFormat.BO1)
+            .winningPoints(21)
+            .bracketType(bracketType)
+            .createdAt(Instant.now())
+            .build();
+
+    for (int i = 0; i < players.size(); i++) {
+      tournament
+          .getParticipants()
+          .add(
+              TournamentParticipant.builder()
+                  .tournament(tournament)
+                  .player(players.get(i))
+                  .seedNumber(i + 1)
+                  .build());
+    }
+    return tournament;
+  }
+
+  private TournamentMatch tournamentMatch(
+      Long tournamentMatchId, Tournament tournament, Player firstPlayer, Player secondPlayer) {
+    return TournamentMatch.builder()
+        .tournamentMatchId(tournamentMatchId)
+        .tournament(tournament)
+        .roundNumber(1)
+        .matchNumber(1)
+        .firstPlayer(firstPlayer)
+        .secondPlayer(secondPlayer)
+        .status(TournamentMatchStatus.PENDING)
+        .createdAt(Instant.now())
+        .build();
   }
 
   private CreateTournamentRequest tournamentRequest(List<Long> playerIds) {


### PR DESCRIPTION
## Summary
- add tournament lifecycle statuses and tournament match persistence
- generate single-elimination and round-robin brackets
- record tournament match winners while updating Elo match history
- add tournament UI controls for starting brackets and reporting winners
- cover bracket progression with unit and integration tests

## Summary by Sourcery

Implement a full tournament engine with bracket generation, match progression, and status tracking across the service, persistence, UI, and docs.

New Features:
- Add tournament lifecycle statuses, winner tracking, and timestamps to tournaments.
- Introduce persistent tournament matches with single-elimination and round-robin bracket generation and progression.
- Expose endpoints and UI controls to start tournaments and report match results, integrating with existing match/Elo tracking.

Enhancements:
- Extend tournament responses and mapping to include lifecycle metadata, participants, and generated matches.
- Refine tournaments page layout and styling to display status, brackets, matches, and winner banners.
- Document the tournament engine API, lifecycle, and architecture, including new start/report endpoints and rules.

Build:
- Add a database migration to support tournament status fields and a tournament_match table with indexes and constraints.

Tests:
- Add unit tests for tournament bracket generation and completion rules.
- Add integration tests to cover end-to-end tournament start and final match reporting flows.